### PR TITLE
Add a dump example

### DIFF
--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -1,0 +1,59 @@
+extern crate wasmparser;
+
+use std::io;
+use std::io::prelude::*;
+use std::fs::File;
+use std::str;
+use std::env;
+use wasmparser::Parser;
+use wasmparser::ParserState;
+
+fn get_name(bytes: &[u8]) -> &str {
+    str::from_utf8(bytes).ok().unwrap()
+}
+
+fn main() {
+    let args = env::args().collect::<Vec<_>>();
+    if args.len() != 2 {
+        println!("Usage: {} in.wasm", args[0]);
+        return;
+    }
+
+    let ref buf: Vec<u8> = read_wasm(&args[1]).unwrap();
+    let mut parser = Parser::new(buf);
+    loop {
+        let state = parser.read();
+        match *state {
+            ParserState::ExportSectionEntry {
+                field,
+                ref kind,
+                index,
+            } => {
+                println!("ExportSectionEntry {{ field: \"{}\", kind: {:?}, index: {} }}",
+                         get_name(field),
+                         kind,
+                         index);
+            }
+            ParserState::ImportSectionEntry {
+                module,
+                field,
+                ref ty,
+            } => {
+                println!("ImportSectionEntry {{ module: \"{}\", field: \"{}\", ty: {:?} }}",
+                         get_name(module),
+                         get_name(field),
+                         ty);
+            }
+            ParserState::EndWasm => break,
+            ParserState::Error(msg) => panic!("Error: {}", msg),
+            _ => println!("{:?}", state),
+        }
+    }
+}
+
+fn read_wasm(file: &str) -> io::Result<Vec<u8>> {
+    let mut data = Vec::new();
+    let mut f = File::open(file)?;
+    f.read_to_end(&mut data)?;
+    Ok(data)
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -41,7 +41,7 @@ pub enum SectionCode<'a> {
     Table, // Indirect function table and other tables
     Memory, // Memory attributes
     Global, // Global declarations
-    Export, //Exports
+    Export, // Exports
     Start, // Start function declaration
     Element, // Elements section
     Code, // Function bodies (code)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -458,7 +458,7 @@ fn is_name_prefix(name: &[u8], prefix: &'static str) -> bool {
 pub enum ParserState<'a> {
     Error(&'a str),
     Initial,
-    BeginWasm { magic_number: u32, version: u32 },
+    BeginWasm { version: u32 },
     EndWasm,
     BeginSection(SectionCode<'a>),
     EndSection,
@@ -771,10 +771,7 @@ impl<'a> Parser<'a> {
         if version != WASM_SUPPORTED_VERSION && version != WASM_EXPERIMENTAL_VERSION {
             return Err("Bad version number");
         }
-        self.state = ParserState::BeginWasm {
-            magic_number: magic_number,
-            version: version,
-        };
+        self.state = ParserState::BeginWasm { version: version };
         Ok(())
     }
 


### PR DESCRIPTION
The main patch here adds a dump example, which walks a wasmparser instance through a wasm module and prints out all the ParserState objects it gets.