### PR TITLE
Add a `validate` function for convenient one-off byte sequence validation.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ pub use parser::Ieee64;
 pub use validator::ValidatingParser;
 pub use validator::ValidatingOperatorParser;
 pub use validator::WasmModuleResources;
+pub use validator::validate;
 
 mod parser;
 mod validator;

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1632,3 +1632,23 @@ impl<'b> ValidatingOperatorParser<'b> {
         Ok(op)
     }
 }
+
+/// Test whether the given buffer contains a valid WebAssembly module,
+/// analogous to WebAssembly.validate in the JS API.
+pub fn validate(bytes: &[u8]) -> bool {
+    let mut parser = ValidatingParser::new(bytes);
+    loop {
+        let state = parser.read();
+        match *state {
+            ParserState::EndWasm => return true,
+            ParserState::Error(_) => return false,
+            _ => (),
+        }
+    }
+}
+
+#[test]
+fn test_validate() {
+    assert!(validate(&[0x0, 0x61, 0x73, 0x6d, 0x1, 0x0, 0x0, 0x0]));
+    assert!(!validate(&[0x0, 0x61, 0x73, 0x6d, 0x2, 0x0, 0x0, 0x0]));
+}


### PR DESCRIPTION
I wrote a simple `validate` helper function for a different project, which just wraps a ValidatingParser. It may be useful for others as well. It's analogous to [`WebAssembly.validate`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/validate) in the WebAssembly JS API.