### PR TITLE
Changes in the API/states

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/yurydelendik/wasmparser.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/yurydelendik/wasmparser.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/yurydelendik/wasmparser.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.8.2"
+version = "0.9.0"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/yurydelendik/wasmparser.rs"

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -157,8 +157,6 @@ mod simple_tests {
         expect_state!(parser.read(), ParserState::BeginSection { code: SectionCode::Code, .. });
         expect_state!(parser.read(), ParserState::BeginFunctionBody { .. });
         expect_state!(parser.read_with_input(ParserInput::SkipFunctionBody),
-            ParserState::EndFunctionBody);
-        expect_state!(parser.read_with_input(ParserInput::SkipSection),
             ParserState::EndSection);
         expect_state!(parser.read(), ParserState::EndWasm);
     }


### PR DESCRIPTION
Changes:

* Fixes #31 - data segment is read in chunks
* Fixes #30 - does not read custom sections by default
* Skips end markers after skipping function/section body


