### PR TITLE
Split BeginFunctionBody into two states, to handle locals separately.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.9.4"
+version = "0.10.0"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/yurydelendik/wasmparser.rs"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -596,7 +596,12 @@ impl<'a> BinaryReader<'a> {
     pub fn read_local_decl(&mut self, locals_total: &mut usize) -> Result<(u32, Type)> {
         let count = self.read_var_u32()?;
         let value_type = self.read_type()?;
-        *locals_total += count as usize;
+        *locals_total = locals_total.checked_add(count as usize).ok_or_else(||
+            BinaryReaderError {
+                message: "locals_total is out of bounds",
+                offset: self.position - 1,
+            }
+        )?;
         if *locals_total > MAX_WASM_FUNCTION_LOCALS {
             return Err(BinaryReaderError {
                 message: "local_count is out of bounds",

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -604,7 +604,7 @@ impl<'a> BinaryReader<'a> {
         )?;
         if *locals_total > MAX_WASM_FUNCTION_LOCALS {
             return Err(BinaryReaderError {
-                message: "local_count is out of bounds",
+                message: "locals_total is out of bounds",
                 offset: self.position - 1,
             });
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -585,9 +585,9 @@ impl<'a> BinaryReader<'a> {
         let local_count = self.read_var_u32()? as usize;
         if local_count > MAX_WASM_FUNCTION_LOCALS {
             return Err(BinaryReaderError {
-                message: "local_count is out of bounds",
-                offset: self.position - 1,
-            });
+                           message: "local_count is out of bounds",
+                           offset: self.position - 1,
+                       });
         }
         Ok(local_count)
     }
@@ -596,17 +596,19 @@ impl<'a> BinaryReader<'a> {
     pub fn read_local_decl(&mut self, locals_total: &mut usize) -> Result<(u32, Type)> {
         let count = self.read_var_u32()?;
         let value_type = self.read_type()?;
-        *locals_total = locals_total.checked_add(count as usize).ok_or_else(||
-            BinaryReaderError {
-                message: "locals_total is out of bounds",
-                offset: self.position - 1,
-            }
-        )?;
+        *locals_total = locals_total
+            .checked_add(count as usize)
+            .ok_or_else(|| {
+                            BinaryReaderError {
+                                message: "locals_total is out of bounds",
+                                offset: self.position - 1,
+                            }
+                        })?;
         if *locals_total > MAX_WASM_FUNCTION_LOCALS {
             return Err(BinaryReaderError {
-                message: "locals_total is out of bounds",
-                offset: self.position - 1,
-            });
+                           message: "locals_total is out of bounds",
+                           offset: self.position - 1,
+                       });
         }
         Ok((count, value_type))
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -134,6 +134,7 @@ mod simple_tests {
         expect_state!(parser.read(), ParserState::EndSection);
         expect_state!(parser.read(), ParserState::BeginSection { code: SectionCode::Code, .. });
         expect_state!(parser.read(), ParserState::BeginFunctionBody { .. });
+        expect_state!(parser.read(), ParserState::FunctionBodyLocals { .. });
         expect_state!(parser.read(), ParserState::CodeOperator(_));
         expect_state!(parser.read(), ParserState::EndFunctionBody);
         expect_state!(parser.read(), ParserState::EndSection);

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1441,7 +1441,7 @@ impl<'a> ValidatingParser<'a> {
                         self.create_validation_error("func type is not defined");
                 }
             }
-            ParserState::FunctionBodyLocals { ref locals, .. } => {
+            ParserState::FunctionBodyLocals { ref locals } => {
                 let index = (self.current_func_index + self.func_imports_count) as usize;
                 let ref func_type = self.types[self.func_type_indices[index] as usize];
                 self.current_operator_validator = Some(OperatorValidator::new(func_type, locals));

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1434,16 +1434,17 @@ impl<'a> ValidatingParser<'a> {
                     }
                 }
             }
-            ParserState::BeginFunctionBody { ref locals, .. } => {
+            ParserState::BeginFunctionBody { .. } => {
                 let index = (self.current_func_index + self.func_imports_count) as usize;
                 if index as usize >= self.func_type_indices.len() {
                     self.validation_error =
                         self.create_validation_error("func type is not defined");
-                } else {
-                    let ref func_type = self.types[self.func_type_indices[index] as usize];
-                    self.current_operator_validator = Some(OperatorValidator::new(func_type,
-                                                                                  locals));
                 }
+            }
+            ParserState::FunctionBodyLocals { ref locals, .. } => {
+                let index = (self.current_func_index + self.func_imports_count) as usize;
+                let ref func_type = self.types[self.func_type_indices[index] as usize];
+                self.current_operator_validator = Some(OperatorValidator::new(func_type, locals));
             }
             ParserState::CodeOperator(ref operator) => {
                 let check = self.current_operator_validator
@@ -1487,14 +1488,16 @@ impl<'a> ValidatingParser<'a> {
     pub fn create_validating_operator_parser<'b>(&mut self) -> ValidatingOperatorParser<'b>
         where 'a: 'b
     {
-        let (operator_validator, func_body_offset) = match *self.last_state() {
-            ParserState::BeginFunctionBody {
-                ref locals,
-                ref range,
-            } => {
+        let func_body_offset = match *self.last_state() {
+            ParserState::BeginFunctionBody { .. } => self.parser.current_position(),
+            _ => panic!("Invalid reader state"),
+        };
+        self.read();
+        let operator_validator = match *self.last_state() {
+            ParserState::FunctionBodyLocals { ref locals } => {
                 let index = (self.current_func_index + self.func_imports_count) as usize;
                 let ref func_type = self.types[self.func_type_indices[index] as usize];
-                (OperatorValidator::new(func_type, locals), range.start)
+                OperatorValidator::new(func_type, locals)
             }
             _ => panic!("Invalid reader state"),
         };


### PR DESCRIPTION
This allows users of `create_binary_reader` to read the locals themselves
through the resulting `BinaryReader` if they wish to.
