### PR TITLE
Add a BinaryReader function to return the number of bytes remaining.

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -761,6 +761,10 @@ impl<'a> BinaryReader<'a> {
         self.position
     }
 
+    pub fn bytes_remaining(&self) -> usize {
+        self.end - self.position
+    }
+
     pub fn read_bytes(&mut self, size: usize) -> Result<&'a [u8]> {
         self.ensure_has_bytes(size)?;
         let start = self.position;


### PR DESCRIPTION
Cretonne's FuncTranslator likes to log how many bytes are being translated, eg. https://github.com/stoklund/cretonne/blob/master/lib/wasm/src/func_translator.rs#L64. This adds a method so that we can log that information when using a BinaryReader too.