### PR TITLE
Add lifetime parameters to &ParserState return values.

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1264,11 +1264,11 @@ pub enum ParserInput {
 }
 
 pub trait WasmDecoder<'a> {
-    fn read(&mut self) -> &ParserState;
+    fn read(&mut self) -> &ParserState<'a>;
     fn push_input(&mut self, input: ParserInput);
-    fn read_with_input(&mut self, input: ParserInput) -> &ParserState;
+    fn read_with_input(&mut self, input: ParserInput) -> &ParserState<'a>;
     fn create_binary_reader<'b>(&mut self) -> BinaryReader<'b> where 'a: 'b;
-    fn last_state(&self) -> &ParserState;
+    fn last_state(&self) -> &ParserState<'a>;
 }
 
 /// The `Parser` type. A simple event-driven parser of WebAssembly binary
@@ -1961,7 +1961,7 @@ impl<'a> WasmDecoder<'a> for Parser<'a> {
     ///     println!("Second state {:?}", state);
     /// }
     /// ```
-    fn read(&mut self) -> &ParserState {
+    fn read(&mut self) -> &ParserState<'a> {
         let result = self.read_wrapped();
         if result.is_err() {
             self.state = ParserState::Error(result.err().unwrap());
@@ -2059,12 +2059,12 @@ impl<'a> WasmDecoder<'a> for Parser<'a> {
     ///     }
     /// }
     /// ```
-    fn read_with_input(&mut self, input: ParserInput) -> &ParserState {
+    fn read_with_input(&mut self, input: ParserInput) -> &ParserState<'a> {
         self.push_input(input);
         self.read()
     }
 
-    fn last_state(&self) -> &ParserState {
+    fn last_state(&self) -> &ParserState<'a> {
         &self.state
     }
 }

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1538,7 +1538,7 @@ impl<'a> ValidatingParser<'a> {
 }
 
 impl<'a> WasmDecoder<'a> for ValidatingParser<'a> {
-    fn read(&mut self) -> &ParserState {
+    fn read(&mut self) -> &ParserState<'a> {
         if self.validation_error.is_some() {
             panic!("Parser in error state: validation");
         }
@@ -1556,7 +1556,7 @@ impl<'a> WasmDecoder<'a> for ValidatingParser<'a> {
         }
     }
 
-    fn read_with_input(&mut self, input: ParserInput) -> &ParserState {
+    fn read_with_input(&mut self, input: ParserInput) -> &ParserState<'a> {
         self.push_input(input);
         self.read()
     }
@@ -1570,7 +1570,7 @@ impl<'a> WasmDecoder<'a> for ValidatingParser<'a> {
         self.parser.create_binary_reader()
     }
 
-    fn last_state(&self) -> &ParserState {
+    fn last_state(&self) -> &ParserState<'a> {
         if self.validation_error.is_some() {
             self.validation_error.as_ref().unwrap()
         } else {


### PR DESCRIPTION
This change allows library users to keep ParserStates and the data in them alive longer than the Parser itself. For example, if a user wants to do deferred parsing of function bodies, they may want to keep a reference to the slice of the data representing the function body live after the main `Parser` is finished, so that they can construct a `BinaryReader` for it and decode it at some later time.
