### PR TITLE
Add no_std support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,17 @@ exclude = ["fuzz/"]
 
 [dependencies]
 
+[dependencies.hashmap_core]
+version = "0.1.1"
+optional = true
+
 [badges]
 travis-ci = { repository = "yurydelendik/wasmparser.rs" }
+
+[features]
+# The "std" feature enables use of libstd. The "no_std" feature enables use
+# of some minimal std-like replacement libraries. At least one of these two
+# features needs to be enabled.
+default = ["std"]
+std = []
+no_std = ["hashmap_core"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ optional = true
 travis-ci = { repository = "yurydelendik/wasmparser.rs" }
 
 [features]
-# The "std" feature enables use of libstd. The "no_std" feature enables use
+# The "std" feature enables use of libstd. The "core" feature enables use
 # of some minimal std-like replacement libraries. At least one of these two
 # features needs to be enabled.
 default = ["std"]
 std = []
-no_std = ["hashmap_core"]
+core = ["hashmap_core"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,16 @@
 //! this is not the right library for you. You could however, build such
 //! a data-structure using this library.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), feature(alloc))]
+
+#[cfg(not(feature = "std"))]
+extern crate hashmap_core;
+
+#[cfg(not(feature = "std"))]
+#[macro_use]
+extern crate alloc;
+
 pub use parser::WasmDecoder;
 pub use parser::Parser;
 pub use parser::ParserState;
@@ -63,3 +73,12 @@ mod parser;
 mod validator;
 mod limits;
 mod tests;
+
+#[cfg(not(feature = "std"))]
+mod std {
+    pub use core::*;
+    pub use alloc::vec;
+    pub mod collections {
+        pub use hashmap_core::HashSet;
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -15,6 +15,7 @@
 // See https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md
 
 use std::result;
+use std::vec::Vec;
 
 use limits::{MAX_WASM_FUNCTION_LOCALS, MAX_WASM_FUNCTION_PARAMS, MAX_WASM_FUNCTION_RETURNS,
              MAX_WASM_FUNCTION_SIZE, MAX_WASM_STRING_SIZE, MAX_WASM_FUNCTIONS,

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -16,6 +16,7 @@
 use std::cmp::min;
 use std::result;
 use std::collections::HashSet;
+use std::vec::Vec;
 
 use parser::{WasmDecoder, Parser, ParserState, ParserInput, BinaryReaderError, FuncType, Type,
              Operator, ResizableLimits, TableType, ImportSectionEntryType, GlobalType, MemoryType,


### PR DESCRIPTION
This adds `no_std` support to wasmparser.rs.

@eternaleye I've attempted to follow your advice in https://github.com/Cretonne/cretonne/pull/224 and use features additively, so I'm curious if you have any comments. wasmparser.rs uses `HashSet` internally, so to enable use of `hashmap_core` in an additive way, I've also created a `no_std` feature which enables that. You can enable both `std` and `no_std` at the same time, and it behaves like a `std` build. But you have to enable at least one of the two.