### PR TITLE
Update to use fork of hashmap_core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ exclude = ["fuzz/"]
 
 [dependencies]
 
-[dependencies.hashmap_core]
-version = "0.1.1"
+[dependencies.hashmap_core2]
+version = "0.0.1"
 optional = true
 
 [badges]
@@ -25,4 +25,4 @@ travis-ci = { repository = "yurydelendik/wasmparser.rs" }
 # features needs to be enabled.
 default = ["std"]
 std = []
-core = ["hashmap_core"]
+core = ["hashmap_core2"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 #![cfg_attr(not(feature = "std"), feature(alloc))]
 
 #[cfg(not(feature = "std"))]
-extern crate hashmap_core;
+extern crate hashmap_core2 as hashmap_core;
 
 #[cfg(not(feature = "std"))]
 #[macro_use]


### PR DESCRIPTION
The `hashmap_core` crate is out-of-date and doesn't build with the latest nightly.