### PR TITLE
Implement anyref etc. from the reference-types proposal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.17.3"
+version = "0.18.0"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/yurydelendik/wasmparser.rs"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -76,6 +76,7 @@ pub enum Type {
     F32,
     F64,
     AnyFunc,
+    AnyRef,
     Func,
     EmptyBlockType,
 }
@@ -670,6 +671,7 @@ impl<'a> BinaryReader<'a> {
             -0x03 => Ok(Type::F32),
             -0x04 => Ok(Type::F64),
             -0x10 => Ok(Type::AnyFunc),
+            -0x11 => Ok(Type::AnyRef),
             -0x20 => Ok(Type::Func),
             -0x40 => Ok(Type::EmptyBlockType),
             _ => Err(BinaryReaderError {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -340,6 +340,8 @@ pub enum Operator<'a> {
     I64Const { value: i64 },
     F32Const { value: Ieee32 },
     F64Const { value: Ieee64 },
+    RefNull,
+    RefIsNull,
     I32Eqz,
     I32Eq,
     I32Ne,
@@ -1536,6 +1538,9 @@ impl<'a> BinaryReader<'a> {
             0xc2 => Operator::I64Extend8S,
             0xc3 => Operator::I64Extend16S,
             0xc4 => Operator::I64Extend32S,
+
+            0xd0 => Operator::RefNull,
+            0xd1 => Operator::RefIsNull,
 
             0xfc => self.read_0xfc_operator()?,
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -24,6 +24,7 @@ mod simple_tests {
     const VALIDATOR_CONFIG: Option<ValidatingParserConfig> = Some(ValidatingParserConfig {
         operator_config: OperatorValidatorConfig {
             enable_threads: true,
+            enable_reference_types: true,
         },
     });
 


### PR DESCRIPTION
This implements anyref, ref.null, and ref.isnull, from https://github.com/WebAssembly/reference-types.

This doesn't add any tests yet, because wabt doesn't yet support these types, but we'll add those tests when we can, and we'll test this with the SpiderMonkey testsuite once we hook everything up.