### PR TITLE
Fix various clippy warnings

### DIFF
--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -20,8 +20,8 @@ fn main() {
         return;
     }
 
-    let ref buf: Vec<u8> = read_wasm(&args[1]).unwrap();
-    let mut parser = Parser::new(buf);
+    let buf: Vec<u8> = read_wasm(&args[1]).unwrap();
+    let mut parser = Parser::new(&buf);
     loop {
         let state = parser.read();
         match *state {

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -20,8 +20,8 @@ fn main() {
         return;
     }
 
-    let ref buf: Vec<u8> = read_wasm(&args[1]).unwrap();
-    let mut parser = Parser::new(buf);
+    let buf: Vec<u8> = read_wasm(&args[1]).unwrap();
+    let mut parser = Parser::new(&buf);
     loop {
         let state = parser.read();
         match *state {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -750,9 +750,9 @@ impl<'a> BinaryReader<'a> {
             returns.push(self.read_type()?);
         }
         Ok(FuncType {
-            form: form,
-            params: params,
-            returns: returns,
+            form,
+            params,
+            returns,
         })
     }
 
@@ -824,10 +824,7 @@ impl<'a> BinaryReader<'a> {
                 } else {
                     CustomSectionKind::Unknown
                 };
-                Ok(SectionCode::Custom {
-                    name: name,
-                    kind: kind,
-                })
+                Ok(SectionCode::Custom { name, kind })
             }
             1 => Ok(SectionCode::Type),
             2 => Ok(SectionCode::Import),
@@ -877,10 +874,7 @@ impl<'a> BinaryReader<'a> {
         for _ in 0..count {
             let index = self.read_var_u32()?;
             let name = self.read_string()?;
-            result.push(Naming {
-                index: index,
-                name: name,
-            });
+            result.push(Naming { index, name });
         }
         Ok(result)
     }
@@ -1737,7 +1731,7 @@ impl<'a> Parser<'a> {
                 offset: self.reader.position - 4,
             });
         }
-        self.state = ParserState::BeginWasm { version: version };
+        self.state = ParserState::BeginWasm { version };
         Ok(())
     }
 
@@ -1800,11 +1794,7 @@ impl<'a> Parser<'a> {
             }
         }
 
-        self.state = ParserState::ImportSectionEntry {
-            module: module,
-            field: field,
-            ty: ty,
-        };
+        self.state = ParserState::ImportSectionEntry { module, field, ty };
         self.section_entries_left -= 1;
         Ok(())
     }
@@ -1858,11 +1848,7 @@ impl<'a> Parser<'a> {
         let field = self.reader.read_string()?;
         let kind = self.reader.read_external_kind()?;
         let index = self.reader.read_var_u32()?;
-        self.state = ParserState::ExportSectionEntry {
-            field: field,
-            kind: kind,
-            index: index,
-        };
+        self.state = ParserState::ExportSectionEntry { field, kind, index };
         self.section_entries_left -= 1;
         Ok(())
     }
@@ -2061,10 +2047,10 @@ impl<'a> Parser<'a> {
             }
         };
         self.state = ParserState::RelocSectionEntry(RelocEntry {
-            ty: ty,
-            offset: offset,
-            index: index,
-            addend: addend,
+            ty,
+            offset,
+            index,
+            addend,
         });
         self.section_entries_left -= 1;
         Ok(())

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -900,23 +900,23 @@ impl<'a> BinaryReader<'a> {
 
     pub fn read_u32(&mut self) -> Result<u32> {
         self.ensure_has_bytes(4)?;
-        let b1 = self.buffer[self.position] as u32;
-        let b2 = self.buffer[self.position + 1] as u32;
-        let b3 = self.buffer[self.position + 2] as u32;
-        let b4 = self.buffer[self.position + 3] as u32;
+        let b1 = u32::from(self.buffer[self.position]);
+        let b2 = u32::from(self.buffer[self.position + 1]);
+        let b3 = u32::from(self.buffer[self.position + 2]);
+        let b4 = u32::from(self.buffer[self.position + 3]);
         self.position += 4;
         Ok(b1 | (b2 << 8) | (b3 << 16) | (b4 << 24))
     }
 
     pub fn read_u64(&mut self) -> Result<u64> {
-        let w1 = self.read_u32()? as u64;
-        let w2 = self.read_u32()? as u64;
+        let w1 = u64::from(self.read_u32()?);
+        let w2 = u64::from(self.read_u32()?);
         Ok(w1 | (w2 << 32))
     }
 
     pub fn read_u8(&mut self) -> Result<u32> {
         self.ensure_has_byte()?;
-        let b = self.buffer[self.position] as u32;
+        let b = u32::from(self.buffer[self.position]);
         self.position += 1;
         Ok(b)
     }
@@ -998,7 +998,7 @@ impl<'a> BinaryReader<'a> {
         let mut shift = 0;
         loop {
             let byte = self.read_u8()?;
-            result |= ((byte & 0x7F) as i64) << shift;
+            result |= i64::from(byte & 0x7F) << shift;
             if shift >= 57 {
                 let continuation_bit = (byte & 0x80) != 0;
                 let sign_and_unused_bit = ((byte << 1) as i8) >> (64 - shift);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -267,7 +267,7 @@ pub struct RelocEntry {
 pub struct Ieee32(u32);
 
 impl Ieee32 {
-    pub fn bits(&self) -> u32 {
+    pub fn bits(self) -> u32 {
         self.0
     }
 }
@@ -280,7 +280,7 @@ impl Ieee32 {
 pub struct Ieee64(u64);
 
 impl Ieee64 {
-    pub fn bits(&self) -> u64 {
+    pub fn bits(self) -> u64 {
         self.0
     }
 }

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -299,7 +299,7 @@ struct OperatorValidator {
 impl OperatorValidator {
     pub fn new(
         func_type: &FuncType,
-        locals: &Vec<(u32, Type)>,
+        locals: &[(u32, Type)],
         config: OperatorValidatorConfig,
     ) -> OperatorValidator {
         let mut local_types = Vec::new();

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -235,7 +235,7 @@ impl OperatorAction {
             }
             OperatorAction::ChangeFrameWithTypes(remove_count, ref new_items) => {
                 OperatorAction::remove_frame_stack_types(func_state, remove_count);
-                if new_items.len() == 0 {
+                if new_items.is_empty() {
                     return;
                 }
                 func_state.stack_types.extend_from_slice(new_items);
@@ -458,10 +458,10 @@ impl OperatorValidator {
         let return_types2 = &block2.return_types;
         if block1.jump_to_top || block2.jump_to_top {
             if block1.jump_to_top {
-                if !block2.jump_to_top && return_types2.len() != 0 {
+                if !block2.jump_to_top && !return_types2.is_empty() {
                     return Err("block types do not match");
                 }
-            } else if return_types1.len() != 0 {
+            } else if !return_types1.is_empty() {
                 return Err("block types do not match");
             }
         } else if *return_types1 != *return_types2 {
@@ -597,7 +597,7 @@ impl OperatorValidator {
                 if func_state.blocks.len() == 1 {
                     OperatorAction::EndFunction
                 } else {
-                    if last_block.is_else_allowed && last_block.return_types.len() > 0 {
+                    if last_block.is_else_allowed && !last_block.return_types.is_empty() {
                         return Err("else is expected: if block has type");
                     }
                     OperatorAction::PopBlock
@@ -1516,7 +1516,7 @@ impl<'a> ValidatingParser<'a> {
         }
         let type_index = self.func_type_indices[func_index as usize];
         let ty = &self.types[type_index as usize];
-        if ty.params.len() > 0 || ty.returns.len() > 0 {
+        if !ty.params.is_empty() || !ty.returns.is_empty() {
             return self.create_error("invlid start function type");
         }
         Ok(())

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1535,7 +1535,7 @@ impl<'a> ValidatingParser<'a> {
                     order_state.unwrap()
                 }
             }
-            previous @ _ => {
+            previous => {
                 if let Some(order_state_unwraped) = order_state {
                     if previous >= order_state_unwraped {
                         return self.create_error("section out of order");

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1640,7 +1640,7 @@ impl<'a> ValidatingParser<'a> {
                         global_count: self.globals.len(),
                         validated: false,
                     });
-                    self.globals.push(global_type.clone());
+                    self.globals.push(global_type);
                 }
             }
             ParserState::BeginInitExpressionBody => {

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1238,23 +1238,23 @@ pub struct ValidatingParser<'a> {
 
 impl<'a> WasmModuleResources for ValidatingParser<'a> {
     fn types(&self) -> &[FuncType] {
-        return &self.types;
+        &self.types
     }
 
     fn tables(&self) -> &[TableType] {
-        return &self.tables;
+        &self.tables
     }
 
     fn memories(&self) -> &[MemoryType] {
-        return &self.memories;
+        &self.memories
     }
 
     fn globals(&self) -> &[GlobalType] {
-        return &self.globals;
+        &self.globals
     }
 
     fn func_type_indices(&self) -> &[u32] {
-        return &self.func_type_indices;
+        &self.func_type_indices
     }
 }
 
@@ -1349,7 +1349,7 @@ impl<'a> ValidatingParser<'a> {
     fn check_value_type(&self, ty: Type) -> ValidatorResult<'a, ()> {
         match ty {
             Type::I32 | Type::I64 | Type::F32 | Type::F64 => Ok(()),
-            _ => return self.create_error("invalid value type"),
+            _ => self.create_error("invalid value type"),
         }
     }
 
@@ -1820,7 +1820,7 @@ pub struct ValidatingOperatorParser<'b> {
 
 impl<'b> ValidatingOperatorParser<'b> {
     pub fn eof(&self) -> bool {
-        return self.end_function;
+        self.end_function
     }
 
     pub fn current_position(&self) -> usize {


### PR DESCRIPTION
This doesn't fix all the clippy warnings, just a rough pass through them. Some of these are subjective, so feel free to disagree; the fixes are split up into separate patches to make it easy to drop individual ones.