### PR TITLE
Change wasmparser's license to "Apache-2.0 WITH LLVM-exception".

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wasmparser"
 version = "0.19.1"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
-license = "Apache-2.0"
+license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/yurydelendik/wasmparser.rs"
 keywords = ["parser", "WebAssembly", "wasm"]
 description = """

--- a/LICENSE
+++ b/LICENSE
@@ -175,3 +175,45 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+--- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.


### PR DESCRIPTION
We are planning to make a minor change to wasmparser's license, changing it from "Apache-2.0" to "Apache-2.0 WITH LLVM-exception". This is the license the LLVM project is planning to transition to [0], and it is registered with SPDX [1].

[0] http://llvm.org/foundation/relicensing/
[1] https://spdx.org/licenses/LLVM-exception.html

LLVM-exception adds a clause providing that the output of compilation isn't subject to the attribution requirements, and a clause providing explicit GPLv2 compatibility. The full text of the license can be found on the LLVM relicensing page [2].

[2] http://llvm.org/foundation/relicensing/LICENSE.txt