### PR TITLE
Add a way to build a `FunctionBody` using a raw byte buffer.

### DIFF
--- a/src/readers/code_section.rs
+++ b/src/readers/code_section.rs
@@ -25,6 +25,10 @@ pub struct FunctionBody<'a> {
 }
 
 impl<'a> FunctionBody<'a> {
+    pub fn new(offset: usize, data: &'a [u8]) -> Self {
+        Self { offset, data }
+    }
+
     pub fn get_binary_reader<'b>(&self) -> BinaryReader<'b>
     where
         'a: 'b,


### PR DESCRIPTION
This will be useful in SpiderMonkey where we decode most of the module up front, and then hand off parts of the code section to worker threads for compilation, so they just want to construct a `FunctionBody` and then start decoding.