### PR TITLE
Export OperatorValidatorConfig so that wasmparser users can use it.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ pub use primitives::TableType;
 pub use primitives::Type;
 
 pub use validator::validate;
+pub use validator::OperatorValidatorConfig;
 pub use validator::ValidatingOperatorParser;
 pub use validator::ValidatingParser;
 pub use validator::WasmModuleResources;


### PR DESCRIPTION
`validate` is exported, and takes an `OperatorValidatorConfig` to configure it, so make `OperatorValidatorConfig` available too.