### PR TITLE
Implement mutable global imports.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@ pub use validator::validate;
 pub use validator::OperatorValidatorConfig;
 pub use validator::ValidatingOperatorParser;
 pub use validator::ValidatingParser;
+pub use validator::ValidatingParserConfig;
 pub use validator::WasmModuleResources;
 
 pub use readers::CodeSectionReader;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -28,6 +28,7 @@ mod simple_tests {
             enable_threads: true,
             enable_reference_types: true,
         },
+        mutable_global_imports: true,
     });
 
     fn read_file_data(path: &PathBuf) -> Vec<u8> {

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1259,10 +1259,14 @@ impl OperatorValidator {
 #[derive(Copy, Clone)]
 pub struct ValidatingParserConfig {
     pub operator_config: OperatorValidatorConfig,
+
+    pub mutable_global_imports: bool,
 }
 
 const DEFAULT_VALIDATING_PARSER_CONFIG: ValidatingParserConfig = ValidatingParserConfig {
     operator_config: DEFAULT_OPERATOR_VALIDATOR_CONFIG,
+
+    mutable_global_imports: false,
 };
 
 pub struct ValidatingParser<'a> {
@@ -1443,7 +1447,7 @@ impl<'a> ValidatingParser<'a> {
                 if self.globals.len() >= MAX_WASM_GLOBALS {
                     return self.create_error("functions count out of bounds");
                 }
-                if global_type.mutable {
+                if global_type.mutable && !self.config.mutable_global_imports {
                     return self.create_error("global imports are required to be immutable");
                 }
                 self.check_global_type(global_type)
@@ -1506,7 +1510,7 @@ impl<'a> ValidatingParser<'a> {
                     return self.create_error("exported global index out of bounds");
                 }
                 let global = &self.globals[index as usize];
-                if global.mutable {
+                if global.mutable && !self.config.mutable_global_imports {
                     return self.create_error("exported global must be const");
                 }
             }


### PR DESCRIPTION
This adds support for mutable globals in the validator, as described here: https://github.com/WebAssembly/mutable-global/

Also, export `ValidatingParserConfig` too, since that's also needed.