### PR TITLE
Minor updates found when integrating into wasm-bindgen tooling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/yurydelendik/wasmparser.rs"

--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -9,10 +9,6 @@ use wasmparser::Parser;
 use wasmparser::ParserState;
 use wasmparser::WasmDecoder;
 
-fn get_name(bytes: &[u8]) -> &str {
-    str::from_utf8(bytes).ok().unwrap()
-}
-
 fn main() {
     let args = env::args().collect::<Vec<_>>();
     if args.len() != 2 {
@@ -32,9 +28,7 @@ fn main() {
             } => {
                 println!(
                     "ExportSectionEntry {{ field: \"{}\", kind: {:?}, index: {} }}",
-                    get_name(field),
-                    kind,
-                    index
+                    field, kind, index
                 );
             }
             ParserState::ImportSectionEntry {
@@ -44,9 +38,7 @@ fn main() {
             } => {
                 println!(
                     "ImportSectionEntry {{ module: \"{}\", field: \"{}\", ty: {:?} }}",
-                    get_name(module),
-                    get_name(field),
-                    ty
+                    module, field, ty
                 );
             }
             ParserState::EndWasm => break,

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -9,10 +9,6 @@ use wasmparser::Parser;
 use wasmparser::ParserState;
 use wasmparser::WasmDecoder;
 
-fn get_name(bytes: &[u8]) -> &str {
-    str::from_utf8(bytes).ok().unwrap()
-}
-
 fn main() {
     let args = env::args().collect::<Vec<_>>();
     if args.len() != 2 {
@@ -31,10 +27,10 @@ fn main() {
             ParserState::ExportSectionEntry {
                 field, ref kind, ..
             } => {
-                println!("  Export {} {:?}", get_name(field), kind);
+                println!("  Export {} {:?}", field, kind);
             }
             ParserState::ImportSectionEntry { module, field, .. } => {
-                println!("  Import {}::{}", get_name(module), get_name(field))
+                println!("  Import {}::{}", module, field)
             }
             ParserState::EndWasm => break,
             ParserState::Error(err) => panic!("Error: {:?}", err),

--- a/src/binary_reader.rs
+++ b/src/binary_reader.rs
@@ -359,6 +359,7 @@ impl<'a> BinaryReader<'a> {
         self.skip_var_32()?;
         Ok(BrTable {
             buffer: &self.buffer[start..self.position],
+            cnt: targets_len as usize,
         })
     }
 
@@ -1171,6 +1172,12 @@ impl<'a> BinaryReader<'a> {
 }
 
 impl<'a> BrTable<'a> {
+    /// Returns the number of `br_table` entries, not including the default
+    /// label
+    pub fn len(&self) -> usize {
+        self.cnt
+    }
+
     /// Reads br_table entries.
     ///
     /// # Examples

--- a/src/binary_reader.rs
+++ b/src/binary_reader.rs
@@ -14,8 +14,8 @@
  */
 
 use std::boxed::Box;
-use std::vec::Vec;
 use std::str;
+use std::vec::Vec;
 
 use limits::{
     MAX_WASM_FUNCTION_LOCALS, MAX_WASM_FUNCTION_PARAMS, MAX_WASM_FUNCTION_RETURNS,
@@ -551,13 +551,10 @@ impl<'a> BinaryReader<'a> {
             });
         }
         let bytes = self.read_bytes(len)?;
-        str::from_utf8(bytes)
-            .map_err(|_| {
-                BinaryReaderError {
-                    message: "non-utf8 string",
-                    offset: self.original_position() - 1,
-                }
-            })
+        str::from_utf8(bytes).map_err(|_| BinaryReaderError {
+            message: "non-utf8 string",
+            offset: self.original_position() - 1,
+        })
     }
 
     fn read_memarg_of_align(&mut self, align: u32) -> Result<MemoryImmediate> {
@@ -777,7 +774,7 @@ impl<'a> BinaryReader<'a> {
                 return Err(BinaryReaderError {
                     message: "Unknown 0xFE opcode",
                     offset: self.original_position() - 1,
-                })
+                });
             }
         })
     }
@@ -1060,7 +1057,7 @@ impl<'a> BinaryReader<'a> {
                 return Err(BinaryReaderError {
                     message: "Unknown opcode",
                     offset: self.original_position() - 1,
-                })
+                });
             }
         })
     }
@@ -1081,7 +1078,7 @@ impl<'a> BinaryReader<'a> {
                 return Err(BinaryReaderError {
                     message: "Unknown 0xfc opcode",
                     offset: self.original_position() - 1,
-                })
+                });
             }
         })
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -47,7 +47,7 @@ pub struct LocalName<'a> {
 
 #[derive(Debug)]
 pub enum NameEntry<'a> {
-    Module(&'a [u8]),
+    Module(&'a str),
     Function(Box<[Naming<'a>]>),
     Local(Box<[LocalName<'a>]>),
 }
@@ -86,15 +86,15 @@ pub enum ParserState<'a> {
 
     TypeSectionEntry(FuncType),
     ImportSectionEntry {
-        module: &'a [u8],
-        field: &'a [u8],
+        module: &'a str,
+        field: &'a str,
         ty: ImportSectionEntryType,
     },
     FunctionSectionEntry(u32),
     TableSectionEntry(TableType),
     MemorySectionEntry(MemoryType),
     ExportSectionEntry {
-        field: &'a [u8],
+        field: &'a str,
         kind: ExternalKind,
         index: u32,
     },
@@ -132,7 +132,7 @@ pub enum ParserState<'a> {
     RelocSectionEntry(RelocEntry),
     LinkingSectionEntry(LinkingType),
 
-    SourceMappingURL(&'a [u8]),
+    SourceMappingURL(&'a str),
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -269,33 +269,33 @@ impl<'a> Parser<'a> {
             ParserSectionReader::CodeSectionReader(ref reader) => return reader.original_position(),
             ParserSectionReader::DataSectionReader(ref reader) => return reader.original_position(),
             ParserSectionReader::ElementSectionReader(ref reader) => {
-                return reader.original_position()
+                return reader.original_position();
             }
             ParserSectionReader::ExportSectionReader(ref reader) => {
-                return reader.original_position()
+                return reader.original_position();
             }
             ParserSectionReader::FunctionSectionReader(ref reader) => {
-                return reader.original_position()
+                return reader.original_position();
             }
             ParserSectionReader::GlobalSectionReader(ref reader) => {
-                return reader.original_position()
+                return reader.original_position();
             }
             ParserSectionReader::ImportSectionReader(ref reader) => {
-                return reader.original_position()
+                return reader.original_position();
             }
             ParserSectionReader::MemorySectionReader(ref reader) => {
-                return reader.original_position()
+                return reader.original_position();
             }
             ParserSectionReader::TableSectionReader(ref reader) => {
-                return reader.original_position()
+                return reader.original_position();
             }
             ParserSectionReader::TypeSectionReader(ref reader) => return reader.original_position(),
             ParserSectionReader::NameSectionReader(ref reader) => return reader.original_position(),
             ParserSectionReader::LinkingSectionReader(ref reader) => {
-                return reader.original_position()
+                return reader.original_position();
             }
             ParserSectionReader::RelocSectionReader(ref reader) => {
-                return reader.original_position()
+                return reader.original_position();
             }
             _ => (),
         };

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -14,6 +14,8 @@
  */
 
 use std::boxed::Box;
+use std::error::Error;
+use std::fmt;
 use std::result;
 
 #[derive(Debug, Copy, Clone)]
@@ -23,6 +25,14 @@ pub struct BinaryReaderError {
 }
 
 pub type Result<T> = result::Result<T, BinaryReaderError>;
+
+impl Error for BinaryReaderError {}
+
+impl fmt::Display for BinaryReaderError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{} (at offset {})", self.message, self.offset)
+    }
+}
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum CustomSectionKind {

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -39,7 +39,7 @@ pub enum CustomSectionKind {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SectionCode<'a> {
     Custom {
-        name: &'a [u8],
+        name: &'a str,
         kind: CustomSectionKind,
     },
     Type,     // Function signature declarations
@@ -129,7 +129,7 @@ pub struct MemoryImmediate {
 #[derive(Debug, Copy, Clone)]
 pub struct Naming<'a> {
     pub index: u32,
-    pub name: &'a [u8],
+    pub name: &'a str,
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -170,6 +170,7 @@ pub enum RelocType {
 #[derive(Debug)]
 pub struct BrTable<'a> {
     pub(crate) buffer: &'a [u8],
+    pub(crate) cnt: usize,
 }
 
 /// An IEEE binary32 immediate floating point value, represented as a u32

--- a/src/readers/export_section.rs
+++ b/src/readers/export_section.rs
@@ -20,7 +20,7 @@ use super::{
 
 #[derive(Debug, Copy, Clone)]
 pub struct Export<'a> {
-    pub field: &'a [u8],
+    pub field: &'a str,
     pub kind: ExternalKind,
     pub index: u32,
 }

--- a/src/readers/import_section.rs
+++ b/src/readers/import_section.rs
@@ -20,8 +20,8 @@ use super::{
 
 #[derive(Debug, Copy, Clone)]
 pub struct Import<'a> {
-    pub module: &'a [u8],
-    pub field: &'a [u8],
+    pub module: &'a str,
+    pub field: &'a str,
     pub ty: ImportSectionEntryType,
 }
 

--- a/src/readers/module.rs
+++ b/src/readers/module.rs
@@ -200,7 +200,7 @@ impl<'a> Section<'a> {
         }
     }
 
-    pub fn get_sourcemappingurl_section_content<'b>(&self) -> Result<&'b [u8]>
+    pub fn get_sourcemappingurl_section_content<'b>(&self) -> Result<&'b str>
     where
         'a: 'b,
     {

--- a/src/readers/name_section.rs
+++ b/src/readers/name_section.rs
@@ -24,7 +24,7 @@ pub struct ModuleName<'a> {
 }
 
 impl<'a> ModuleName<'a> {
-    pub fn get_name<'b>(&self) -> Result<&'b [u8]>
+    pub fn get_name<'b>(&self) -> Result<&'b str>
     where
         'a: 'b,
     {

--- a/src/readers/sourcemappingurl_section.rs
+++ b/src/readers/sourcemappingurl_section.rs
@@ -18,7 +18,7 @@ use super::{BinaryReader, BinaryReaderError, Result};
 pub(crate) fn read_sourcemappingurl_section_content<'a>(
     data: &'a [u8],
     offset: usize,
-) -> Result<&'a [u8]> {
+) -> Result<&'a str> {
     let mut reader = BinaryReader::new_with_offset(data, offset);
     let url = reader.read_string()?;
     if !reader.eof() {

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1282,7 +1282,7 @@ pub struct ValidatingParser<'a> {
     current_func_index: u32,
     func_imports_count: u32,
     init_expression_state: Option<InitExpressionState>,
-    exported_names: HashSet<Vec<u8>>,
+    exported_names: HashSet<String>,
     current_operator_validator: Option<OperatorValidator>,
     config: ValidatingParserConfig,
 }
@@ -1342,16 +1342,6 @@ impl<'a> ValidatingParser<'a> {
             message,
             offset: self.read_position.unwrap(),
         }))
-    }
-
-    fn check_utf8(&self, bytes: &[u8]) -> ValidatorResult<'a, ()> {
-        match str::from_utf8(bytes) {
-            Ok(_) => Ok(()),
-            Err(utf8_error) => match utf8_error.error_len() {
-                None => self.create_error("Invalid utf-8: unexpected end of string"),
-                Some(_) => self.create_error("Invalid utf-8: unexpected byte"),
-            },
-        }
     }
 
     fn check_value_type(&self, ty: Type) -> ValidatorResult<'a, ()> {
@@ -1415,12 +1405,8 @@ impl<'a> ValidatingParser<'a> {
 
     fn check_import_entry(
         &self,
-        module: &[u8],
-        field: &[u8],
         import_type: &ImportSectionEntryType,
     ) -> ValidatorResult<'a, ()> {
-        self.check_utf8(module)?;
-        self.check_utf8(field)?;
         match *import_type {
             ImportSectionEntryType::Function(type_index) => {
                 if self.func_type_indices.len() >= MAX_WASM_FUNCTIONS {
@@ -1481,12 +1467,11 @@ impl<'a> ValidatingParser<'a> {
 
     fn check_export_entry(
         &self,
-        field: &[u8],
+        field: &str,
         kind: ExternalKind,
         index: u32,
     ) -> ValidatorResult<'a, ()> {
-        self.check_utf8(field)?;
-        if self.exported_names.contains(&Vec::from(field)) {
+        if self.exported_names.contains(field) {
             return self.create_error("non-unique export name");
         }
         match kind {
@@ -1532,9 +1517,6 @@ impl<'a> ValidatingParser<'a> {
 
     fn process_begin_section(&self, code: &SectionCode) -> ValidatorResult<'a, SectionOrderState> {
         let order_state = SectionOrderState::from_section_code(code);
-        if let SectionCode::Custom { name, .. } = *code {
-            self.check_utf8(name)?;
-        }
         Ok(match self.section_order_state {
             SectionOrderState::Initial => {
                 if order_state.is_none() {
@@ -1583,11 +1565,10 @@ impl<'a> ValidatingParser<'a> {
                 }
             }
             ParserState::ImportSectionEntry {
-                module,
-                field,
                 ref ty,
+                ..
             } => {
-                let check = self.check_import_entry(module, field, ty);
+                let check = self.check_import_entry(ty);
                 if check.is_err() {
                     self.validation_error = check.err();
                 } else {
@@ -1666,7 +1647,7 @@ impl<'a> ValidatingParser<'a> {
             }
             ParserState::ExportSectionEntry { field, kind, index } => {
                 self.validation_error = self.check_export_entry(field, kind, index).err();
-                self.exported_names.insert(Vec::from(field));
+                self.exported_names.insert(field.to_string());
             }
             ParserState::StartSectionEntry(func_index) => {
                 self.validation_error = self.check_start(func_index).err();

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1403,10 +1403,7 @@ impl<'a> ValidatingParser<'a> {
         self.check_value_type(global_type.content_type)
     }
 
-    fn check_import_entry(
-        &self,
-        import_type: &ImportSectionEntryType,
-    ) -> ValidatorResult<'a, ()> {
+    fn check_import_entry(&self, import_type: &ImportSectionEntryType) -> ValidatorResult<'a, ()> {
         match *import_type {
             ImportSectionEntryType::Function(type_index) => {
                 if self.func_type_indices.len() >= MAX_WASM_FUNCTIONS {
@@ -1564,10 +1561,7 @@ impl<'a> ValidatingParser<'a> {
                     self.types.push(func_type.clone());
                 }
             }
-            ParserState::ImportSectionEntry {
-                ref ty,
-                ..
-            } => {
+            ParserState::ImportSectionEntry { ref ty, .. } => {
                 let check = self.check_import_entry(ty);
                 if check.is_err() {
                     self.validation_error = check.err();


### PR DESCRIPTION
This is a few minor updates that I ran into when preparing https://github.com/rustwasm/walrus/pull/26, a crate for eventually powering wasm-bindgen tooling. Most of it's pretty straightforward, but I'm particularly curious what you think about the change of signature in `read_string`!