### PR TITLE
Fill out support for table manipulation instructions

### DIFF
--- a/src/binary_reader.rs
+++ b/src/binary_reader.rs
@@ -821,7 +821,7 @@ impl<'a> BinaryReader<'a> {
             },
             0x11 => Operator::CallIndirect {
                 index: self.read_var_u32()?,
-                table_index: self.read_var_u1()?,
+                table_index: self.read_var_u32()?,
             },
             0x1a => Operator::Drop,
             0x1b => Operator::Select,
@@ -839,6 +839,12 @@ impl<'a> BinaryReader<'a> {
             },
             0x24 => Operator::SetGlobal {
                 global_index: self.read_var_u32()?,
+            },
+            0x25 => Operator::TableGet {
+                table: self.read_var_u32()?,
+            },
+            0x26 => Operator::TableSet {
+                table: self.read_var_u32()?,
             },
             0x28 => Operator::I32Load {
                 memarg: self.read_memarg()?,
@@ -1158,6 +1164,15 @@ impl<'a> BinaryReader<'a> {
                     });
                 }
                 Operator::TableCopy
+            }
+
+            0x0f => {
+                let table = self.read_var_u32()?;
+                Operator::TableGrow { table }
+            }
+            0x10 => {
+                let table = self.read_var_u32()?;
+                Operator::TableSize { table }
             }
 
             _ => {

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -418,6 +418,10 @@ pub enum Operator<'a> {
     TableInit { segment: u32 },
     ElemDrop { segment: u32 },
     TableCopy,
+    TableGet { table: u32 },
+    TableSet { table: u32 },
+    TableGrow { table: u32 },
+    TableSize { table: u32 },
 
     // 0xFE operators
     // https://github.com/WebAssembly/threads/blob/master/proposals/threads/Overview.md

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1574,6 +1574,37 @@ impl OperatorValidator {
                 self.check_operands(func_state, &[Type::I32, Type::I32, Type::I32])?;
                 OperatorAction::ChangeFrame(3)
             }
+            Operator::TableGet { table } => {
+                self.check_reference_types_enabled()?;
+                if table as usize >= resources.tables().len() {
+                    return Err("table index out of bounds");
+                }
+                self.check_operands(func_state, &[Type::I32])?;
+                OperatorAction::ChangeFrameWithType(1, Type::AnyRef)
+            }
+            Operator::TableSet { table } => {
+                self.check_reference_types_enabled()?;
+                if table as usize >= resources.tables().len() {
+                    return Err("table index out of bounds");
+                }
+                self.check_operands(func_state, &[Type::I32, Type::AnyRef])?;
+                OperatorAction::ChangeFrame(2)
+            }
+            Operator::TableGrow { table } => {
+                self.check_reference_types_enabled()?;
+                if table as usize >= resources.tables().len() {
+                    return Err("table index out of bounds");
+                }
+                self.check_operands(func_state, &[Type::I32])?;
+                OperatorAction::ChangeFrameWithType(1, Type::I32)
+            }
+            Operator::TableSize { table } => {
+                self.check_reference_types_enabled()?;
+                if table as usize >= resources.tables().len() {
+                    return Err("table index out of bounds");
+                }
+                OperatorAction::ChangeFrameWithType(1, Type::I32)
+            }
         })
     }
 


### PR DESCRIPTION
This commit adds support for the instructions added as part of the
reference types proposal, currently:

* `table.get`
* `table.set`
* `table.grow`
* `table.size`

While not specified in the current proposal, all encodings are currently
selected to match Firefox's implementation