### PR TITLE
Use an explicit `dyn` for trait objects

### DIFF
--- a/src/operators_validator.rs
+++ b/src/operators_validator.rs
@@ -422,7 +422,7 @@ impl OperatorValidator {
     fn check_memory_index(
         &self,
         memory_index: u32,
-        resources: &WasmModuleResources,
+        resources: &dyn WasmModuleResources,
     ) -> OperatorValidatorResult<()> {
         if memory_index as usize >= resources.memories().len() {
             return Err("no liner memories are present");
@@ -433,7 +433,7 @@ impl OperatorValidator {
     fn check_shared_memory_index(
         &self,
         memory_index: u32,
-        resources: &WasmModuleResources,
+        resources: &dyn WasmModuleResources,
     ) -> OperatorValidatorResult<()> {
         if memory_index as usize >= resources.memories().len() {
             return Err("no liner memories are present");
@@ -448,7 +448,7 @@ impl OperatorValidator {
         &self,
         memarg: &MemoryImmediate,
         max_align: u32,
-        resources: &WasmModuleResources,
+        resources: &dyn WasmModuleResources,
     ) -> OperatorValidatorResult<()> {
         self.check_memory_index(0, resources)?;
         let align = memarg.flags;
@@ -489,7 +489,7 @@ impl OperatorValidator {
     fn check_shared_memarg_wo_align(
         &self,
         _: &MemoryImmediate,
-        resources: &WasmModuleResources,
+        resources: &dyn WasmModuleResources,
     ) -> OperatorValidatorResult<()> {
         self.check_shared_memory_index(0, resources)?;
         Ok(())
@@ -540,7 +540,7 @@ impl OperatorValidator {
     pub(crate) fn process_operator(
         &mut self,
         operator: &Operator,
-        resources: &WasmModuleResources,
+        resources: &dyn WasmModuleResources,
     ) -> OperatorValidatorResult<FunctionEnd> {
         if self.func_state.end_function {
             return Err("unexpected operator");

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -179,7 +179,7 @@ impl<'a> ValidatingParser<'a> {
         }
     }
 
-    pub fn get_resources(&self) -> &WasmModuleResources {
+    pub fn get_resources(&self) -> &dyn WasmModuleResources {
         &self.resources
     }
 
@@ -748,7 +748,7 @@ impl<'b> ValidatingOperatorParser<'b> {
     ///     }
     /// }
     /// ```
-    pub fn next<'c>(&mut self, resources: &WasmModuleResources) -> Result<Operator<'c>>
+    pub fn next<'c>(&mut self, resources: &dyn WasmModuleResources) -> Result<Operator<'c>>
     where
         'b: 'c,
     {
@@ -780,7 +780,7 @@ impl<'b> ValidatingOperatorParser<'b> {
 pub fn validate_function_body(
     bytes: &[u8],
     func_index: u32,
-    resources: &WasmModuleResources,
+    resources: &dyn WasmModuleResources,
     operator_config: Option<OperatorValidatorConfig>,
 ) -> bool {
     let operator_config = operator_config.unwrap_or(DEFAULT_OPERATOR_VALIDATOR_CONFIG);


### PR DESCRIPTION
Silences a bunch of warnings.