### PR TITLE
Correct error message

### DIFF
--- a/src/binary_reader.rs
+++ b/src/binary_reader.rs
@@ -249,7 +249,7 @@ impl<'a> BinaryReader<'a> {
         let returns_len = self.read_var_u32()? as usize;
         if returns_len > MAX_WASM_FUNCTION_RETURNS {
             return Err(BinaryReaderError {
-                message: "function params size is out of bound",
+                message: "function returns size is out of bound",
                 offset: self.original_position() - 1,
             });
         }


### PR DESCRIPTION
When the function return is out of bounds, emit a message about the function return not the function parameter.