### PR TITLE
Fixed compilation when compiling with no std

### DIFF
--- a/src/binary_reader.rs
+++ b/src/binary_reader.rs
@@ -814,7 +814,7 @@ impl<'a> BinaryReader<'a> {
         } else {
             self.position = position;
             let idx = self.read_var_s33()?;
-            if idx < 0 || idx > (std::u32::MAX as i64) {
+            if idx < 0 || idx > (::std::u32::MAX as i64) {
                 return Err(BinaryReaderError {
                     message: "invalid function type",
                     offset: position,


### PR DESCRIPTION
When compiling with `features = ["core"]` (without std), there was an error.

This PR fixes it :)