### PR TITLE
Replace V8x16Shuffle with V8x16Shuffle1 and V8x16Shuffle2Imm opcodes.

### DIFF
--- a/src/binary_reader.rs
+++ b/src/binary_reader.rs
@@ -1418,6 +1418,14 @@ impl<'a> BinaryReader<'a> {
             0xb0 => Operator::F32x4ConvertUI32x4,
             0xb1 => Operator::F64x2ConvertSI64x2,
             0xb2 => Operator::F64x2ConvertUI64x2,
+            0xc0 => Operator::V8x16Shuffle1,
+            0xc1 => {
+                let mut lanes = [0 as SIMDLaneIndex; 16];
+                for i in 0..16 {
+                    lanes[i] = self.read_lane_index(32)?
+                }
+                Operator::V8x16Shuffle2Imm { lanes }
+            }
             _ => {
                 return Err(BinaryReaderError {
                     message: "Unknown 0xfd opcode",

--- a/src/operators_validator.rs
+++ b/src/operators_validator.rs
@@ -1486,6 +1486,19 @@ impl OperatorValidator {
                 self.check_operands_2(Type::V128, Type::I32)?;
                 self.func_state.change_frame_with_type(2, Type::V128)?;
             }
+            Operator::V8x16Shuffle1 => {
+                self.check_simd_enabled()?;
+                self.check_operands_2(Type::V128, Type::V128)?;
+                self.func_state.change_frame_with_type(2, Type::V128)?;
+            }
+            Operator::V8x16Shuffle2Imm { ref lanes } => {
+                self.check_simd_enabled()?;
+                self.check_operands_2(Type::V128, Type::V128)?;
+                for i in lanes {
+                    self.check_simd_lane_index(*i, 32)?;
+                }
+                self.func_state.change_frame_with_type(2, Type::V128)?;
+            }
 
             Operator::MemoryInit { segment } => {
                 self.check_bulk_memory_enabled()?;

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -650,4 +650,6 @@ pub enum Operator<'a> {
     F32x4ConvertUI32x4,
     F64x2ConvertSI64x2,
     F64x2ConvertUI64x2,
+    V8x16Shuffle1,
+    V8x16Shuffle2Imm { lanes: [SIMDLaneIndex; 16] },
 }


### PR DESCRIPTION
This matches the update to the SIMD proposal at https://github.com/WebAssembly/simd/commit/7f4d54d4c9a525f6e04c7edcecdc1969f27e5d09

This causes the existing test/simd.wasm to fail. I'd appreciate instructions on how to update it.