### PR TITLE
fix error in benchmarks, added the required  field

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -11,6 +11,7 @@ const VALIDATOR_CONFIG: Option<ValidatingParserConfig> = Some(ValidatingParserCo
         enable_reference_types: true,
         enable_simd: true,
         enable_bulk_memory: true,
+        enable_multi_value:true,
     },
     mutable_global_imports: true,
 });

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -11,7 +11,7 @@ const VALIDATOR_CONFIG: Option<ValidatingParserConfig> = Some(ValidatingParserCo
         enable_reference_types: true,
         enable_simd: true,
         enable_bulk_memory: true,
-        enable_multi_value:true,
+        enable_multi_value: true,
     },
     mutable_global_imports: true,
 });


### PR DESCRIPTION
The `enable_multi_value` field was missing