### PR TITLE
Rename v8x16.shuffle1 and v8x16.shuffle2_imm to v8x16.swizzle and v8x16.shuffle_imm.

### DIFF
--- a/src/binary_reader.rs
+++ b/src/binary_reader.rs
@@ -1418,13 +1418,13 @@ impl<'a> BinaryReader<'a> {
             0xb0 => Operator::F32x4ConvertUI32x4,
             0xb1 => Operator::F64x2ConvertSI64x2,
             0xb2 => Operator::F64x2ConvertUI64x2,
-            0xc0 => Operator::V8x16Shuffle1,
+            0xc0 => Operator::V8x16Swizzle,
             0xc1 => {
                 let mut lanes = [0 as SIMDLaneIndex; 16];
                 for i in 0..16 {
                     lanes[i] = self.read_lane_index(32)?
                 }
-                Operator::V8x16Shuffle2Imm { lanes }
+                Operator::V8x16ShuffleImm { lanes }
             }
             _ => {
                 return Err(BinaryReaderError {

--- a/src/operators_validator.rs
+++ b/src/operators_validator.rs
@@ -1486,12 +1486,12 @@ impl OperatorValidator {
                 self.check_operands_2(Type::V128, Type::I32)?;
                 self.func_state.change_frame_with_type(2, Type::V128)?;
             }
-            Operator::V8x16Shuffle1 => {
+            Operator::V8x16Swizzle => {
                 self.check_simd_enabled()?;
                 self.check_operands_2(Type::V128, Type::V128)?;
                 self.func_state.change_frame_with_type(2, Type::V128)?;
             }
-            Operator::V8x16Shuffle2Imm { ref lanes } => {
+            Operator::V8x16ShuffleImm { ref lanes } => {
                 self.check_simd_enabled()?;
                 self.check_operands_2(Type::V128, Type::V128)?;
                 for i in lanes {

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -650,6 +650,6 @@ pub enum Operator<'a> {
     F32x4ConvertUI32x4,
     F64x2ConvertSI64x2,
     F64x2ConvertUI64x2,
-    V8x16Shuffle1,
-    V8x16Shuffle2Imm { lanes: [SIMDLaneIndex; 16] },
+    V8x16Swizzle,
+    V8x16ShuffleImm { lanes: [SIMDLaneIndex; 16] },
 }


### PR DESCRIPTION
@tlively tells me that the SIMD group has decided to change the names, but they haven't updated the SIMD proposal repo yet in https://github.com/WebAssembly/wabt/pull/1116#issuecomment-512884716 .