### PR TITLE
Add the 4 new LoadSplat SIMD instructions.

### DIFF
--- a/src/binary_reader.rs
+++ b/src/binary_reader.rs
@@ -1429,7 +1429,7 @@ impl<'a> BinaryReader<'a> {
                 memarg: self.read_memarg_of_align(2)?,
             },
             0xc5 => Operator::I64x2LoadSplat {
-                memarg: self.read_memarg_of_align(4)?,
+                memarg: self.read_memarg_of_align(3)?,
             },
             _ => {
                 return Err(BinaryReaderError {

--- a/src/binary_reader.rs
+++ b/src/binary_reader.rs
@@ -1418,7 +1418,7 @@ impl<'a> BinaryReader<'a> {
                     lanes[i] = self.read_lane_index(32)?
                 }
                 Operator::V8x16Shuffle { lanes }
-            },
+            }
             0xc2 => Operator::I8x16LoadSplat {
                 memarg: self.read_memarg_of_align(4)?,
             },

--- a/src/binary_reader.rs
+++ b/src/binary_reader.rs
@@ -1420,16 +1420,16 @@ impl<'a> BinaryReader<'a> {
                 Operator::V8x16Shuffle { lanes }
             }
             0xc2 => Operator::I8x16LoadSplat {
-                memarg: self.read_memarg_of_align(1)?,
+                memarg: self.read_memarg_of_align(0)?,
             },
             0xc3 => Operator::I16x8LoadSplat {
                 memarg: self.read_memarg_of_align(1)?,
             },
             0xc4 => Operator::I32x4LoadSplat {
-                memarg: self.read_memarg_of_align(1)?,
+                memarg: self.read_memarg_of_align(2)?,
             },
             0xc5 => Operator::I64x2LoadSplat {
-                memarg: self.read_memarg_of_align(2)?,
+                memarg: self.read_memarg_of_align(4)?,
             },
             _ => {
                 return Err(BinaryReaderError {

--- a/src/binary_reader.rs
+++ b/src/binary_reader.rs
@@ -1247,13 +1247,6 @@ impl<'a> BinaryReader<'a> {
             0x02 => Operator::V128Const {
                 value: self.read_v128()?,
             },
-            0x03 => {
-                let mut lanes = [0 as SIMDLaneIndex; 16];
-                for i in 0..16 {
-                    lanes[i] = self.read_lane_index(32)?
-                }
-                Operator::V8x16Shuffle { lanes }
-            }
             0x04 => Operator::I8x16Splat,
             0x05 => Operator::I8x16ExtractLaneS {
                 lane: self.read_lane_index(16)?,
@@ -1419,13 +1412,25 @@ impl<'a> BinaryReader<'a> {
             0xb1 => Operator::F64x2ConvertSI64x2,
             0xb2 => Operator::F64x2ConvertUI64x2,
             0xc0 => Operator::V8x16Swizzle,
-            0xc1 => {
+            0x03 | 0xc1 => {
                 let mut lanes = [0 as SIMDLaneIndex; 16];
                 for i in 0..16 {
                     lanes[i] = self.read_lane_index(32)?
                 }
-                Operator::V8x16ShuffleImm { lanes }
-            }
+                Operator::V8x16Shuffle { lanes }
+            },
+            0xc2 => Operator::I8x16LoadSplat {
+                memarg: self.read_memarg_of_align(4)?,
+            },
+            0xc3 => Operator::I16x8LoadSplat {
+                memarg: self.read_memarg_of_align(4)?,
+            },
+            0xc4 => Operator::I32x4LoadSplat {
+                memarg: self.read_memarg_of_align(4)?,
+            },
+            0xc5 => Operator::I64x2LoadSplat {
+                memarg: self.read_memarg_of_align(4)?,
+            },
             _ => {
                 return Err(BinaryReaderError {
                     message: "Unknown 0xfd opcode",

--- a/src/binary_reader.rs
+++ b/src/binary_reader.rs
@@ -1420,16 +1420,16 @@ impl<'a> BinaryReader<'a> {
                 Operator::V8x16Shuffle { lanes }
             }
             0xc2 => Operator::I8x16LoadSplat {
-                memarg: self.read_memarg_of_align(4)?,
+                memarg: self.read_memarg_of_align(1)?,
             },
             0xc3 => Operator::I16x8LoadSplat {
-                memarg: self.read_memarg_of_align(4)?,
+                memarg: self.read_memarg_of_align(1)?,
             },
             0xc4 => Operator::I32x4LoadSplat {
-                memarg: self.read_memarg_of_align(4)?,
+                memarg: self.read_memarg_of_align(1)?,
             },
             0xc5 => Operator::I64x2LoadSplat {
-                memarg: self.read_memarg_of_align(4)?,
+                memarg: self.read_memarg_of_align(2)?,
             },
             _ => {
                 return Err(BinaryReaderError {

--- a/src/operators_validator.rs
+++ b/src/operators_validator.rs
@@ -1250,14 +1250,6 @@ impl OperatorValidator {
                 self.check_simd_enabled()?;
                 self.func_state.change_frame_with_type(0, Type::V128)?;
             }
-            Operator::V8x16Shuffle { ref lanes } => {
-                self.check_simd_enabled()?;
-                self.check_operands_2(Type::V128, Type::V128)?;
-                for i in lanes {
-                    self.check_simd_lane_index(*i, 32)?;
-                }
-                self.func_state.change_frame_with_type(2, Type::V128)?;
-            }
             Operator::I8x16Splat | Operator::I16x8Splat | Operator::I32x4Splat => {
                 self.check_simd_enabled()?;
                 self.check_operands_1(Type::I32)?;
@@ -1491,13 +1483,21 @@ impl OperatorValidator {
                 self.check_operands_2(Type::V128, Type::V128)?;
                 self.func_state.change_frame_with_type(2, Type::V128)?;
             }
-            Operator::V8x16ShuffleImm { ref lanes } => {
+            Operator::V8x16Shuffle { ref lanes } => {
                 self.check_simd_enabled()?;
                 self.check_operands_2(Type::V128, Type::V128)?;
                 for i in lanes {
                     self.check_simd_lane_index(*i, 32)?;
                 }
                 self.func_state.change_frame_with_type(2, Type::V128)?;
+            }
+            Operator::I8x16LoadSplat { ref memarg }
+            | Operator::I16x8LoadSplat { ref memarg }
+            | Operator::I32x4LoadSplat { ref memarg }
+            | Operator::I64x2LoadSplat { ref memarg } => {
+                self.check_simd_enabled()?;
+                self.check_memarg(memarg, 4, resources)?;
+                self.func_state.change_frame_with_type(1, Type::V128)?;
             }
 
             Operator::MemoryInit { segment } => {

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -513,7 +513,6 @@ pub enum Operator<'a> {
     V128Load { memarg: MemoryImmediate },
     V128Store { memarg: MemoryImmediate },
     V128Const { value: V128 },
-    V8x16Shuffle { lanes: [SIMDLaneIndex; 16] },
     I8x16Splat,
     I8x16ExtractLaneS { lane: SIMDLaneIndex },
     I8x16ExtractLaneU { lane: SIMDLaneIndex },
@@ -651,5 +650,9 @@ pub enum Operator<'a> {
     F64x2ConvertSI64x2,
     F64x2ConvertUI64x2,
     V8x16Swizzle,
-    V8x16ShuffleImm { lanes: [SIMDLaneIndex; 16] },
+    V8x16Shuffle { lanes: [SIMDLaneIndex; 16] },
+    I8x16LoadSplat { memarg: MemoryImmediate },
+    I16x8LoadSplat { memarg: MemoryImmediate },
+    I32x4LoadSplat { memarg: MemoryImmediate },
+    I64x2LoadSplat { memarg: MemoryImmediate },
 }


### PR DESCRIPTION
Fix name of "v8x16.shuffle_imm" to standardized "v8x16.shuffle".