### PR TITLE
Fix parsing of SIMD opcode.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.35.0"
+version = "0.35.1"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/yurydelendik/wasmparser.rs"

--- a/src/binary_reader.rs
+++ b/src/binary_reader.rs
@@ -1239,7 +1239,7 @@ impl<'a> BinaryReader<'a> {
     }
 
     fn read_0xfd_operator(&mut self) -> Result<Operator<'a>> {
-        let code = self.read_u8()? as u8;
+        let code = self.read_var_u32()? as u32;
         Ok(match code {
             0x00 => Operator::V128Load {
                 memarg: self.read_memarg()?,

--- a/src/binary_reader.rs
+++ b/src/binary_reader.rs
@@ -1239,7 +1239,7 @@ impl<'a> BinaryReader<'a> {
     }
 
     fn read_0xfd_operator(&mut self) -> Result<Operator<'a>> {
-        let code = self.read_var_u32()? as u32;
+        let code = self.read_var_u32()? as u8;
         Ok(match code {
             0x00 => Operator::V128Load {
                 memarg: self.read_memarg()?,

--- a/src/binary_reader.rs
+++ b/src/binary_reader.rs
@@ -416,6 +416,23 @@ impl<'a> BinaryReader<'a> {
         Ok(b)
     }
 
+    pub fn read_var_u8(&mut self) -> Result<u32> {
+        // Optimization for single byte i32.
+        let byte = self.read_u8()?;
+        if (byte & 0x80) == 0 {
+            return Ok(byte);
+        }
+
+        let result = (self.read_u8()? << 7) | (byte & 0x7F);
+        if result >= 0x100 {
+            return Err(BinaryReaderError {
+                message: "Invalid var_u8",
+                offset: self.original_position() - 1,
+            });
+        }
+        Ok(result)
+    }
+
     pub fn read_var_u32(&mut self) -> Result<u32> {
         // Optimization for single byte i32.
         let byte = self.read_u8()?;
@@ -1239,7 +1256,7 @@ impl<'a> BinaryReader<'a> {
     }
 
     fn read_0xfd_operator(&mut self) -> Result<Operator<'a>> {
-        let code = self.read_var_u32()? as u8;
+        let code = self.read_var_u8()? as u8;
         Ok(match code {
             0x00 => Operator::V128Load {
                 memarg: self.read_memarg()?,


### PR DESCRIPTION
The SIMD proposal declares its opcode with the grammar:
```
instr ::= ...
        | 0xFD simdop:varuint32 ...
```

`wabt` treats all instructions having prefixes as being LEB128, but I wasn't able to find such text in any 0xfc (Non-trapping Float-to-int Conversions) or 0xfe (Threading proposal for WebAssembly). Neither of them have allocated enough opcodes that it would matter yet.