### PR TITLE
module reader: provide SectionContent enum with readers created

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,7 @@ pub use crate::readers::ProducersSectionReader;
 pub use crate::readers::Reloc;
 pub use crate::readers::RelocSectionReader;
 pub use crate::readers::Section;
+pub use crate::readers::SectionContent;
 pub use crate::readers::SectionIterator;
 pub use crate::readers::SectionIteratorLimited;
 pub use crate::readers::SectionReader;

--- a/src/readers/mod.rs
+++ b/src/readers/mod.rs
@@ -44,6 +44,7 @@ pub use self::init_expr::InitExpr;
 pub use self::memory_section::MemorySectionReader;
 pub use self::module::ModuleReader;
 pub use self::module::Section;
+pub use self::module::SectionContent;
 use self::start_section::read_start_section_content;
 pub use self::table_section::TableSectionReader;
 pub use self::type_section::TypeSectionReader;

--- a/src/readers/module.rs
+++ b/src/readers/module.rs
@@ -263,19 +263,30 @@ impl<'a> Section<'a> {
             SectionCode::Data => SectionContent::Data(self.get_data_section_reader()?),
             SectionCode::Table => SectionContent::Table(self.get_table_section_reader()?),
             SectionCode::Element => SectionContent::Element(self.get_element_section_reader()?),
-            SectionCode::Custom { kind: CustomSectionKind::Name, .. } => SectionContent::Name(self.get_name_section_reader()?),
-            SectionCode::Custom { kind: CustomSectionKind::Producers, .. } => {
-                SectionContent::Producers(self.get_producers_section_reader()?)
-            }
-            SectionCode::Custom { kind: CustomSectionKind::Linking, .. } => SectionContent::Linking(self.get_linking_section_reader()?),
-            SectionCode::Custom { kind: CustomSectionKind::Reloc, .. } => SectionContent::Reloc(self.get_reloc_section_reader()?),
+            SectionCode::Custom {
+                kind: CustomSectionKind::Name,
+                ..
+            } => SectionContent::Name(self.get_name_section_reader()?),
+            SectionCode::Custom {
+                kind: CustomSectionKind::Producers,
+                ..
+            } => SectionContent::Producers(self.get_producers_section_reader()?),
+            SectionCode::Custom {
+                kind: CustomSectionKind::Linking,
+                ..
+            } => SectionContent::Linking(self.get_linking_section_reader()?),
+            SectionCode::Custom {
+                kind: CustomSectionKind::Reloc,
+                ..
+            } => SectionContent::Reloc(self.get_reloc_section_reader()?),
             SectionCode::Start => SectionContent::Start(self.get_start_section_content()?),
             SectionCode::DataCount => {
                 SectionContent::DataCount(self.get_data_count_section_content()?)
             }
-            SectionCode::Custom { kind: CustomSectionKind::SourceMappingURL, .. } => {
-                SectionContent::SourceMappingURL(self.get_sourcemappingurl_section_content()?)
-            }
+            SectionCode::Custom {
+                kind: CustomSectionKind::SourceMappingURL,
+                ..
+            } => SectionContent::SourceMappingURL(self.get_sourcemappingurl_section_content()?),
             SectionCode::Custom { .. } => SectionContent::Custom(self.get_binary_reader()),
         };
         Ok(c)

--- a/src/readers/module.rs
+++ b/src/readers/module.rs
@@ -247,8 +247,61 @@ impl<'a> Section<'a> {
             end: self.offset + self.data.len(),
         }
     }
+
+    pub fn content<'b>(&self) -> Result<SectionContent<'b>>
+    where
+        'a: 'b,
+    {
+        let c = match self.code {
+            SectionCode::Type => SectionContent::Type(self.get_type_section_reader()?),
+            SectionCode::Function => SectionContent::Function(self.get_function_section_reader()?),
+            SectionCode::Code => SectionContent::Code(self.get_code_section_reader()?),
+            SectionCode::Export => SectionContent::Export(self.get_export_section_reader()?),
+            SectionCode::Import => SectionContent::Import(self.get_import_section_reader()?),
+            SectionCode::Global => SectionContent::Global(self.get_global_section_reader()?),
+            SectionCode::Memory => SectionContent::Memory(self.get_memory_section_reader()?),
+            SectionCode::Data => SectionContent::Data(self.get_data_section_reader()?),
+            SectionCode::Table => SectionContent::Table(self.get_table_section_reader()?),
+            SectionCode::Element => SectionContent::Element(self.get_element_section_reader()?),
+            SectionCode::Custom { kind: CustomSectionKind::Name, .. } => SectionContent::Name(self.get_name_section_reader()?),
+            SectionCode::Custom { kind: CustomSectionKind::Producers, .. } => {
+                SectionContent::Producers(self.get_producers_section_reader()?)
+            }
+            SectionCode::Custom { kind: CustomSectionKind::Linking, .. } => SectionContent::Linking(self.get_linking_section_reader()?),
+            SectionCode::Custom { kind: CustomSectionKind::Reloc, .. } => SectionContent::Reloc(self.get_reloc_section_reader()?),
+            SectionCode::Start => SectionContent::Start(self.get_start_section_content()?),
+            SectionCode::DataCount => {
+                SectionContent::DataCount(self.get_data_count_section_content()?)
+            }
+            SectionCode::Custom { kind: CustomSectionKind::SourceMappingURL, .. } => {
+                SectionContent::SourceMappingURL(self.get_sourcemappingurl_section_content()?)
+            }
+            SectionCode::Custom { .. } => SectionContent::Custom(self.get_binary_reader()),
+        };
+        Ok(c)
+    }
 }
 
+pub enum SectionContent<'a> {
+    Type(TypeSectionReader<'a>),
+    Function(FunctionSectionReader<'a>),
+    Code(CodeSectionReader<'a>),
+    Export(ExportSectionReader<'a>),
+    Import(ImportSectionReader<'a>),
+    Global(GlobalSectionReader<'a>),
+    Memory(MemorySectionReader<'a>),
+    Data(DataSectionReader<'a>),
+    Table(TableSectionReader<'a>),
+    Element(ElementSectionReader<'a>),
+    Name(NameSectionReader<'a>),
+    Producers(ProducersSectionReader<'a>),
+    Linking(LinkingSectionReader<'a>),
+    Reloc(RelocSectionReader<'a>),
+    Start(u32),
+    DataCount(u32),
+    SourceMappingURL(&'a str),
+    Custom(BinaryReader<'a>),
+}
 /// Reads top-level WebAssembly file structure: header and sections.
 pub struct ModuleReader<'a> {
     reader: BinaryReader<'a>,


### PR DESCRIPTION
This makes it possible to use a simpler interface as used in cranelift-wasm, and elsewhere. 

I was about to re-implement this big reader/switch from `cranelift_wasm::translate_module` in my own code (with calls to different code with each section reader). Rather than do so I thought I'd see if the library can just provide it. https://github.com/cranestation/cranelift/blob/master/cranelift-wasm/src/module_translator.rs

