### PR TITLE
SectionContent enum abstraction compatible with cranelift-wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.39.0"
+version = "0.39.1"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/yurydelendik/wasmparser.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@ pub use crate::operators_validator::OperatorValidatorConfig;
 pub use crate::operators_validator::WasmModuleResources;
 
 pub use crate::readers::CodeSectionReader;
+pub use crate::readers::CustomSectionContent;
 pub use crate::readers::Data;
 pub use crate::readers::DataKind;
 pub use crate::readers::DataSectionReader;

--- a/src/readers/mod.rs
+++ b/src/readers/mod.rs
@@ -42,6 +42,7 @@ pub use self::import_section::Import;
 pub use self::import_section::ImportSectionReader;
 pub use self::init_expr::InitExpr;
 pub use self::memory_section::MemorySectionReader;
+pub use self::module::CustomSectionContent;
 pub use self::module::ModuleReader;
 pub use self::module::Section;
 pub use self::module::SectionContent;


### PR DESCRIPTION
Thanks for reviewing and merging #132 so quickly yesterday! Unfortunately, I was moving too fast and didn't actually try porting it to cranelift-wasm. In #132, the SectionContent I wrote had some
problems:
* an unknown custom section's name was dropped
* a binary reader was not available for any of the recognized custom
  sections

cranelift-wasm defers decoding custom sections, except for the name
section, to the `environ` by passing the raw bytes.

This patch changes all custom sections to fall under a single variant
of SectionContent. It contains 1. the name, 2. a binary reader of the
content, and 3. an Option<CustomSectionContent<'a>>. The
CustomSectionContent enum has the specialized reader for each recognized
custom section.