### PR TITLE
Allow `[t*] -> [t*]` if blocks with no else

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.39.1"
+version = "0.39.2"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/yurydelendik/wasmparser.rs"

--- a/src/operators_validator.rs
+++ b/src/operators_validator.rs
@@ -689,9 +689,9 @@ impl OperatorValidator {
                 }
                 if {
                     let last_block = &self.func_state.last_block();
-                    last_block.is_else_allowed && !last_block.return_types.is_empty()
+                    last_block.is_else_allowed && last_block.start_types != last_block.return_types
                 } {
-                    return Err("else is expected: if block has type");
+                    return Err("else is expected: if block has a type that can't be implemented with a no-op");
                 }
                 self.func_state.pop_block()
             }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -314,7 +314,6 @@ mod simple_tests {
         }
         assert_eq!(1, tests_count);
     }
-
 }
 
 #[cfg(feature = "std")]
@@ -371,6 +370,9 @@ mod wast_tests {
         let mut features = Features::new();
         if config.operator_config.enable_simd {
             features.enable_simd();
+        }
+        if config.operator_config.enable_multi_value {
+            features.enable_multi_value();
         }
         if config.operator_config.enable_reference_types {
             features.enable_reference_types();
@@ -475,6 +477,16 @@ mod wast_tests {
                 | ("simd_load.wast", _) => true,
                 _ => false,
             },
+        );
+
+        run_proposal_tests(
+            "multi-value",
+            {
+                let mut config: ValidatingParserConfig = default_config();
+                config.operator_config.enable_multi_value = true;
+                config
+            },
+            |_name, _line| false,
         );
 
         run_proposal_tests(


### PR DESCRIPTION
As long as the start and end types are the same, then we don't need to require an `else` block because a no-op will trivially implements that type signature.

This also enables the multi-value proposal spec tests, which test for this.