### PR TITLE
Parse the `table.fill` instruction

### DIFF
--- a/src/binary_reader.rs
+++ b/src/binary_reader.rs
@@ -1244,6 +1244,11 @@ impl<'a> BinaryReader<'a> {
                 Operator::TableSize { table }
             }
 
+            0x11 => {
+                let table = self.read_var_u32()?;
+                Operator::TableFill { table }
+            }
+
             _ => {
                 return Err(BinaryReaderError {
                     message: "Unknown 0xfc opcode",

--- a/src/operators_validator.rs
+++ b/src/operators_validator.rs
@@ -1704,6 +1704,15 @@ impl OperatorValidator {
                 }
                 self.func_state.change_frame_with_type(1, Type::I32)?;
             }
+            Operator::TableFill { table } => {
+                self.check_bulk_memory_enabled()?;
+                let ty = match resources.tables().get(table as usize) {
+                    Some(ty) => ty.element_type,
+                    None => return Err("table index out of bounds"),
+                };
+                self.check_operands(&[Type::I32, ty, Type::I32])?;
+                self.func_state.change_frame(3)?;
+            }
         }
         Ok(FunctionEnd::No)
     }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -435,6 +435,7 @@ pub enum Operator<'a> {
     TableInit { segment: u32 },
     ElemDrop { segment: u32 },
     TableCopy,
+    TableFill { table: u32 },
     TableGet { table: u32 },
     TableSet { table: u32 },
     TableGrow { table: u32 },


### PR DESCRIPTION
Add support for the experimental `table.fill` instruction from its
proposal.