### PR TITLE
Fix passive element reader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.42.1"
+version = "0.43.0"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/yurydelendik/wasmparser.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,7 @@ pub use crate::readers::NamingReader;
 pub use crate::readers::OperatorsReader;
 pub use crate::readers::PassiveElementItem;
 pub use crate::readers::PassiveElementItems;
+pub use crate::readers::PassiveElementItemsReader;
 pub use crate::readers::ProducersField;
 pub use crate::readers::ProducersFieldValue;
 pub use crate::readers::ProducersSectionReader;

--- a/src/readers/mod.rs
+++ b/src/readers/mod.rs
@@ -35,6 +35,7 @@ pub use self::element_section::ElementKind;
 pub use self::element_section::ElementSectionReader;
 pub use self::element_section::PassiveElementItem;
 pub use self::element_section::PassiveElementItems;
+pub use self::element_section::PassiveElementItemsReader;
 pub use self::export_section::Export;
 pub use self::export_section::ExportSectionReader;
 pub use self::function_section::FunctionSectionReader;

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -523,7 +523,7 @@ impl<'a> ValidatingParser<'a> {
             ParserState::DataCountSectionEntry(count) => {
                 self.resources.data_count = Some(count);
             }
-            ParserState::BeginPassiveElementSectionEntry(_ty) => {
+            ParserState::PassiveElementSectionEntry { .. } => {
                 self.resources.element_count += 1;
             }
             ParserState::BeginActiveElementSectionEntry(table_index) => {


### PR DESCRIPTION
The #142 adds parsing of passive element segment. It did not provide support for `WasmDecoder` logic, which caused https://github.com/bytecodealliance/wasmtime/issues/644.

This patch:
- fixes `Parser` and `validate` to support `PassiveElementsEntry` state
- adds test/exampe for passive elements reading
