### PR TITLE
Use actions/checkout@v1 to support submodules checkout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         rust: [stable, beta, nightly]
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
       with:
         submodules: true
     - name: Install Rust
@@ -21,7 +21,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v1
     - name: Install Rust
       run: rustup update stable && rustup default stable && rustup component add rustfmt
     - run: cargo fmt -- --check


### PR DESCRIPTION
This commit fixes the CI by setting `actions/checkout` at version `v1`. The current master of `actions/checkout` now obsoleted the `with: submodules: true` input. See [actions/checkout/releases/tag/v2-beta] for more info.

[actions/checkout/releases/tag/v2-beta]: https://github.com/actions/checkout/releases/tag/v2-beta