### PR TITLE
Improve WasmDecoder::create_binary_reader example

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1127,12 +1127,14 @@ impl<'a> WasmDecoder<'a> for Parser<'a> {
     ///     let ty = &types[function_types[i] as usize];
     ///     println!("\nFunction {} of type {:?}", i, ty);
     ///     // Read the local declarations required by the function body.
-    ///     let mut local_count = reader.read_local_count().unwrap();
-    ///     let mut local_decls = Vec::new();
-    ///     for _ in 0..local_count {
+    ///     let local_decls_len = reader.read_local_count().unwrap();
+    ///     let mut local_decls = Vec::with_capacity(local_decls_len);
+    ///     let mut local_count = ty.params.len();
+    ///     for _ in 0..local_decls_len {
     ///         let local_decl = reader.read_local_decl(&mut local_count).unwrap();
     ///         local_decls.push(local_decl);
     ///     }
+    ///     println!("Function locals: vars {:?}; total {} ", local_decls, local_count);
     ///     // Read the operations of the function body.
     ///     while let Ok(ref op) = reader.read_operator() {
     ///         println!("  {:?}", op);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1129,14 +1129,10 @@ impl<'a> WasmDecoder<'a> for Parser<'a> {
     ///     // Read the local declarations required by the function body.
     ///     let mut local_count = reader.read_local_count().unwrap();
     ///     let mut local_decls = Vec::new();
-    ///     let n = local_count;
-    ///     for _ in 0..n {
+    ///     for _ in 0..local_count {
     ///         let local_decl = reader.read_local_decl(&mut local_count).unwrap();
     ///         local_decls.push(local_decl);
     ///     }
-    ///     println!("    locals: {:?}", local_decls);
-    ///     println!("    local_count (before) = {}", n);
-    ///     println!("    local_count (after)  = {}", local_count);
     ///     // Read the operations of the function body.
     ///     while let Ok(ref op) = reader.read_operator() {
     ///         println!("  {:?}", op);


### PR DESCRIPTION
Improves the code example for `WasmDecoder::create_binary_reader` to make the usage intent more clear according to https://github.com/bytecodealliance/wasmparser/issues/155.