### PR TITLE
Make memarg alignment error message match expected message in SIMD spec tests

### DIFF
--- a/src/operators_validator.rs
+++ b/src/operators_validator.rs
@@ -497,7 +497,7 @@ impl OperatorValidator {
         self.check_memory_index(0, resources)?;
         let align = memarg.flags;
         if align > max_align {
-            return Err("align is required to be at most the number of accessed bytes");
+            return Err("alignment must not be larger than natural");
         }
         Ok(())
     }


### PR DESCRIPTION
See expected error message in https://github.com/WebAssembly/testsuite/blob/814fd73e25efbe96128e46944749ee192d0165fd/proposals/simd/simd_align.wast#L65.