### PR TITLE
Allow memory alignment hints to be within [0, max_align]

### DIFF
--- a/src/binary_reader.rs
+++ b/src/binary_reader.rs
@@ -706,9 +706,9 @@ impl<'a> BinaryReader<'a> {
         })
     }
 
-    fn read_memarg_of_align(&mut self, align: u32) -> Result<MemoryImmediate> {
+    fn read_memarg_of_align(&mut self, max_align: u32) -> Result<MemoryImmediate> {
         let imm = self.read_memarg()?;
-        if align != imm.flags {
+        if imm.flags > max_align {
             return Err(BinaryReaderError {
                 message: "Unexpected memarg alignment",
                 offset: self.original_position() - 1,


### PR DESCRIPTION
As discussed in https://github.com/WebAssembly/simd/issues/162, memory alignment hints allow the full range of values between 0 (1-byte alignment) and max_align (`log2(source byte size)`). For example, an 8-byte (64-bit) load should allow `memarg.align` values of [0, 1, 2, 3] (see https://github.com/WebAssembly/simd/issues/162#issuecomment-568064747). 

This change also attempts to make the comparison a bit more clear.