### PR TITLE
Enable ref-types 'binary.wast' and 'linking.wast' tests

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -501,10 +501,7 @@ mod wast_tests {
                 config
             },
             |name, line| match (name, line) {
-                ("br_table.wast", _)
-                | ("select.wast", _)
-                | ("binary.wast", _)
-                | ("linking.wast", 280) => true,
+                ("br_table.wast", _) | ("select.wast", _) => true,
                 _ => false,
             },
         );


### PR DESCRIPTION
These tests are now passing, possibly because of #168.