### PR TITLE
Refactor BrTable

### DIFF
--- a/src/operators_validator.rs
+++ b/src/operators_validator.rs
@@ -720,7 +720,7 @@ impl OperatorValidator {
             Operator::BrTable { ref table } => {
                 self.check_operands_1(Type::I32)?;
                 let mut depth0: Option<u32> = None;
-                for relative_depth in table {
+                for relative_depth in table.targets_and_default() {
                     if depth0.is_none() {
                         self.check_jump_from_block(relative_depth, 1)?;
                         depth0 = Some(relative_depth);

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -191,11 +191,15 @@ pub enum RelocType {
     GlobalIndexLEB,
 }
 
-/// A br_table entries representation.
+/// A `br_table` entries representation.
 #[derive(Debug, Clone)]
 pub struct BrTable<'a> {
+    /// The underlying bytes buffer representing the already parsed targets.
     pub(crate) buffer: &'a [u8],
-    pub(crate) cnt: usize,
+    /// The number of non-default targets of the `br_table`.
+    pub(crate) len_targets: usize,
+    /// The default target offset of the `br_table`.
+    pub default_offset: u32,
 }
 
 /// An IEEE binary32 immediate floating point value, represented as a u32


### PR DESCRIPTION
Associated issue: https://github.com/bytecodealliance/wasmparser/issues/174

This PR slightly refactors the `BrTable` abstraction of the Wasm `br_table`.

- Adds a new field `default_offset` to `BrTable`
- Removes the `IntoIterator` impl for `&'a BrTable`
- Adds `targets` and `targets_and_default` iterator methods to `BrTable`
- Improves correctness of iteration of `BrTableTargets` (the iterator type)

Let me explain the changes.

- Since the default offset is a required field in the `br_table` we simply add it as a field instead of merging it with the other non-default target offsets.
- I had the feeling that the `IntoIterator` impl was confusing since it was not clear what exactly is being iterated over (with or without default offset?). So the new interface provides two different methods for those two use cases.
- The last thing is a bit more involved. In essence this changes the very simple iterator `next` implementation from
```rust
fn next(&mut self) -> Option<Self::Item> {
    self.reader.read_var_u32().ok()
}
```
to
```rust
fn next(&mut self) -> Option<Self::Item> {
    if self.start == self.end {
        return None;
    }
    let next = self
        .reader
        .read_var_u32()
        // We can expect this not to fail since we can only contruct a
        // `BrTableTargets` iterator from a proper `BrTable` instance
        // which checks the underlying buffer for being a valid `br_table`
        // entries buffer.
        .expect("expected a `br_table` target var_u32");
    self.start += 1;
    Some(next)
}
```
While this might look like a really bad change it actually makes the whole iteration more correct from what I can tell. Please prove me wrong on this because I am actually still a bit confused about what I found: The `empty-br-table` test broke after this change - note, that every other test of the whole test suite continued to work under this change.

From looking at the test snippet it seems to me that the `empty-br-table.wasm` is actually syntactically incorrect, not semantically so it should fail during parsing, not during validation but I might be wrong here.

Why is the old and super fancy small interface working? Tbh I cannot tell for sure but it obviously is more robust against too small buffers. So the iterator will silently yield less elements than there are which is what is incorrect about it imo. But I am still a bit confused because the `create_br_table` function should in theory sort out those malicious cases before they can even exist. Need to dig in deeper.

Please tell me if I am completely wrong about my assumptions so far. @yurydelendik 