### PR TITLE
Use nested import syntax and other import layout

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,6 @@
 # This file tells tools we use rustfmt. We use the default settings.
+
+merge_imports = true
+reorder_imports = true
+imports_layout = "HorizontalVertical"
+max_width = 100

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -20,14 +20,20 @@ extern crate criterion;
 extern crate wasmparser;
 
 use criterion::Criterion;
-use wasmparser::{
-    validate, OperatorValidatorConfig, Parser, ParserState, ValidatingParser,
-    ValidatingParserConfig, WasmDecoder,
+use std::{
+    fs::{read_dir, File},
+    io::Read,
+    path::PathBuf,
 };
-
-use std::fs::{read_dir, File};
-use std::io::Read;
-use std::path::PathBuf;
+use wasmparser::{
+    validate,
+    OperatorValidatorConfig,
+    Parser,
+    ParserState,
+    ValidatingParser,
+    ValidatingParserConfig,
+    WasmDecoder,
+};
 
 fn read_all_wasm<'a, T>(mut d: T)
 where

--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -1,13 +1,7 @@
 extern crate wasmparser;
 
-use std::env;
-use std::fs::File;
-use std::io;
-use std::io::prelude::*;
-use std::str;
-use wasmparser::Parser;
-use wasmparser::ParserState;
-use wasmparser::WasmDecoder;
+use std::{env, fs::File, io, io::prelude::*, str};
+use wasmparser::{Parser, ParserState, WasmDecoder};
 
 fn main() {
     let args = env::args().collect::<Vec<_>>();

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,13 +1,7 @@
 extern crate wasmparser;
 
-use std::env;
-use std::fs::File;
-use std::io;
-use std::io::prelude::*;
-use std::str;
-use wasmparser::Parser;
-use wasmparser::ParserState;
-use wasmparser::WasmDecoder;
+use std::{env, fs::File, io, io::prelude::*, str};
+use wasmparser::{Parser, ParserState, WasmDecoder};
 
 fn main() {
     let args = env::args().collect::<Vec<_>>();

--- a/format-all.sh
+++ b/format-all.sh
@@ -9,4 +9,4 @@ cd "$topdir"
 # Make sure we can find rustfmt.
 export PATH="$PATH:$HOME/.cargo/bin"
 
-exec cargo +stable fmt --all -- "$@"
+exec cargo +nightly fmt --all -- "$@"

--- a/src/binary_reader.rs
+++ b/src/binary_reader.rs
@@ -13,20 +13,40 @@
  * limitations under the License.
  */
 
-use std::boxed::Box;
-use std::convert::TryInto;
-use std::str;
-use std::vec::Vec;
+use std::{boxed::Box, convert::TryInto, str, vec::Vec};
 
-use crate::limits::{
-    MAX_WASM_FUNCTION_LOCALS, MAX_WASM_FUNCTION_PARAMS, MAX_WASM_FUNCTION_RETURNS,
-    MAX_WASM_FUNCTION_SIZE, MAX_WASM_STRING_SIZE,
-};
-
-use crate::primitives::{
-    BinaryReaderError, BrTable, CustomSectionKind, ExternalKind, FuncType, GlobalType, Ieee32,
-    Ieee64, LinkingType, MemoryImmediate, MemoryType, NameType, Operator, RelocType,
-    ResizableLimits, Result, SIMDLaneIndex, SectionCode, TableType, Type, TypeOrFuncType, V128,
+use crate::{
+    limits::{
+        MAX_WASM_FUNCTION_LOCALS,
+        MAX_WASM_FUNCTION_PARAMS,
+        MAX_WASM_FUNCTION_RETURNS,
+        MAX_WASM_FUNCTION_SIZE,
+        MAX_WASM_STRING_SIZE,
+    },
+    primitives::{
+        BinaryReaderError,
+        BrTable,
+        CustomSectionKind,
+        ExternalKind,
+        FuncType,
+        GlobalType,
+        Ieee32,
+        Ieee64,
+        LinkingType,
+        MemoryImmediate,
+        MemoryType,
+        NameType,
+        Operator,
+        RelocType,
+        ResizableLimits,
+        Result,
+        SIMDLaneIndex,
+        SectionCode,
+        TableType,
+        Type,
+        TypeOrFuncType,
+        V128,
+    },
 };
 
 const MAX_WASM_BR_TABLE_SIZE: usize = MAX_WASM_FUNCTION_SIZE;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,102 +23,106 @@
 //! this is not the right library for you. You could however, build such
 //! a data-structure using this library.
 
-pub use crate::binary_reader::BinaryReader;
-pub use crate::binary_reader::Range;
 use crate::binary_reader::SectionHeader;
-
-pub use crate::parser::ElemSectionEntryTable;
-pub use crate::parser::LocalName;
-pub use crate::parser::NameEntry;
-pub use crate::parser::Parser;
-pub use crate::parser::ParserInput;
-pub use crate::parser::ParserState;
-pub use crate::parser::RelocEntry;
-pub use crate::parser::WasmDecoder;
-
-pub use crate::primitives::BinaryReaderError;
-pub use crate::primitives::BrTable;
-pub use crate::primitives::CustomSectionKind;
-pub use crate::primitives::ExternalKind;
-pub use crate::primitives::FuncType;
-pub use crate::primitives::GlobalType;
-pub use crate::primitives::Ieee32;
-pub use crate::primitives::Ieee64;
-pub use crate::primitives::ImportSectionEntryType;
-pub use crate::primitives::LinkingType;
-pub use crate::primitives::MemoryImmediate;
-pub use crate::primitives::MemoryType;
-pub use crate::primitives::NameType;
-pub use crate::primitives::Naming;
-pub use crate::primitives::Operator;
-pub use crate::primitives::RelocType;
-pub use crate::primitives::ResizableLimits;
-pub use crate::primitives::Result;
-pub use crate::primitives::SectionCode;
-pub use crate::primitives::TableType;
-pub use crate::primitives::Type;
-pub use crate::primitives::TypeOrFuncType;
-pub use crate::primitives::V128;
-
-pub use crate::validator::validate;
-pub use crate::validator::validate_function_body;
-pub use crate::validator::ValidatingOperatorParser;
-pub use crate::validator::ValidatingParser;
-pub use crate::validator::ValidatingParserConfig;
-
-pub use crate::module_resources::WasmFuncType;
-pub use crate::module_resources::WasmGlobalType;
-pub use crate::module_resources::WasmMemoryType;
-pub use crate::module_resources::WasmModuleResources;
-pub use crate::module_resources::WasmTableType;
-pub use crate::module_resources::WasmType;
-
 pub(crate) use crate::module_resources::{wasm_func_type_inputs, wasm_func_type_outputs};
-
-pub use crate::operators_validator::OperatorValidatorConfig;
-
-pub use crate::readers::CodeSectionReader;
-pub use crate::readers::CustomSectionContent;
-pub use crate::readers::Data;
-pub use crate::readers::DataKind;
-pub use crate::readers::DataSectionReader;
-pub use crate::readers::Element;
-pub use crate::readers::ElementItem;
-pub use crate::readers::ElementItems;
-pub use crate::readers::ElementItemsReader;
-pub use crate::readers::ElementKind;
-pub use crate::readers::ElementSectionReader;
-pub use crate::readers::Export;
-pub use crate::readers::ExportSectionReader;
-pub use crate::readers::FunctionBody;
-pub use crate::readers::FunctionSectionReader;
-pub use crate::readers::Global;
-pub use crate::readers::GlobalSectionReader;
-pub use crate::readers::Import;
-pub use crate::readers::ImportSectionReader;
-pub use crate::readers::InitExpr;
-pub use crate::readers::LinkingSectionReader;
-pub use crate::readers::LocalsReader;
-pub use crate::readers::MemorySectionReader;
-pub use crate::readers::ModuleReader;
-pub use crate::readers::Name;
-pub use crate::readers::NameSectionReader;
-pub use crate::readers::NamingReader;
-pub use crate::readers::OperatorsReader;
-pub use crate::readers::ProducersField;
-pub use crate::readers::ProducersFieldValue;
-pub use crate::readers::ProducersFieldValuesReader;
-pub use crate::readers::ProducersSectionReader;
-pub use crate::readers::Reloc;
-pub use crate::readers::RelocSectionReader;
-pub use crate::readers::Section;
-pub use crate::readers::SectionContent;
-pub use crate::readers::SectionIterator;
-pub use crate::readers::SectionIteratorLimited;
-pub use crate::readers::SectionReader;
-pub use crate::readers::SectionWithLimitedItems;
-pub use crate::readers::TableSectionReader;
-pub use crate::readers::TypeSectionReader;
+pub use crate::{
+    binary_reader::{BinaryReader, Range},
+    module_resources::{
+        WasmFuncType,
+        WasmGlobalType,
+        WasmMemoryType,
+        WasmModuleResources,
+        WasmTableType,
+        WasmType,
+    },
+    operators_validator::OperatorValidatorConfig,
+    parser::{
+        ElemSectionEntryTable,
+        LocalName,
+        NameEntry,
+        Parser,
+        ParserInput,
+        ParserState,
+        RelocEntry,
+        WasmDecoder,
+    },
+    primitives::{
+        BinaryReaderError,
+        BrTable,
+        CustomSectionKind,
+        ExternalKind,
+        FuncType,
+        GlobalType,
+        Ieee32,
+        Ieee64,
+        ImportSectionEntryType,
+        LinkingType,
+        MemoryImmediate,
+        MemoryType,
+        NameType,
+        Naming,
+        Operator,
+        RelocType,
+        ResizableLimits,
+        Result,
+        SectionCode,
+        TableType,
+        Type,
+        TypeOrFuncType,
+        V128,
+    },
+    readers::{
+        CodeSectionReader,
+        CustomSectionContent,
+        Data,
+        DataKind,
+        DataSectionReader,
+        Element,
+        ElementItem,
+        ElementItems,
+        ElementItemsReader,
+        ElementKind,
+        ElementSectionReader,
+        Export,
+        ExportSectionReader,
+        FunctionBody,
+        FunctionSectionReader,
+        Global,
+        GlobalSectionReader,
+        Import,
+        ImportSectionReader,
+        InitExpr,
+        LinkingSectionReader,
+        LocalsReader,
+        MemorySectionReader,
+        ModuleReader,
+        Name,
+        NameSectionReader,
+        NamingReader,
+        OperatorsReader,
+        ProducersField,
+        ProducersFieldValue,
+        ProducersFieldValuesReader,
+        ProducersSectionReader,
+        Reloc,
+        RelocSectionReader,
+        Section,
+        SectionContent,
+        SectionIterator,
+        SectionIteratorLimited,
+        SectionReader,
+        SectionWithLimitedItems,
+        TableSectionReader,
+        TypeSectionReader,
+    },
+    validator::{
+        validate,
+        validate_function_body,
+        ValidatingOperatorParser,
+        ValidatingParser,
+        ValidatingParserConfig,
+    },
+};
 
 mod binary_reader;
 mod limits;

--- a/src/operators_validator.rs
+++ b/src/operators_validator.rs
@@ -15,10 +15,17 @@
 
 use std::cmp::min;
 
-use crate::primitives::{MemoryImmediate, Operator, SIMDLaneIndex, Type, TypeOrFuncType};
 use crate::{
-    wasm_func_type_inputs, wasm_func_type_outputs, BinaryReaderError, WasmFuncType, WasmGlobalType,
-    WasmMemoryType, WasmModuleResources, WasmTableType, WasmType,
+    primitives::{MemoryImmediate, Operator, SIMDLaneIndex, Type, TypeOrFuncType},
+    wasm_func_type_inputs,
+    wasm_func_type_outputs,
+    BinaryReaderError,
+    WasmFuncType,
+    WasmGlobalType,
+    WasmMemoryType,
+    WasmModuleResources,
+    WasmTableType,
+    WasmType,
 };
 
 #[derive(Debug)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -14,29 +14,66 @@
  */
 // See https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md
 
-use std::boxed::Box;
-use std::vec::Vec;
+use std::{boxed::Box, vec::Vec};
 
-use crate::limits::{
-    MAX_WASM_FUNCTIONS, MAX_WASM_FUNCTION_LOCALS, MAX_WASM_STRING_SIZE, MAX_WASM_TABLE_ENTRIES,
+use crate::{
+    binary_reader::{BinaryReader, Range},
+    limits::{
+        MAX_WASM_FUNCTIONS,
+        MAX_WASM_FUNCTION_LOCALS,
+        MAX_WASM_STRING_SIZE,
+        MAX_WASM_TABLE_ENTRIES,
+    },
+    primitives::{
+        BinaryReaderError,
+        CustomSectionKind,
+        ExternalKind,
+        FuncType,
+        GlobalType,
+        ImportSectionEntryType,
+        LinkingType,
+        MemoryType,
+        Naming,
+        Operator,
+        RelocType,
+        Result,
+        SectionCode,
+        TableType,
+        Type,
+    },
+    readers::{
+        CodeSectionReader,
+        Data,
+        DataKind,
+        DataSectionReader,
+        Element,
+        ElementItem,
+        ElementItems,
+        ElementKind,
+        ElementSectionReader,
+        Export,
+        ExportSectionReader,
+        FunctionBody,
+        FunctionSectionReader,
+        Global,
+        GlobalSectionReader,
+        Import,
+        ImportSectionReader,
+        LinkingSectionReader,
+        MemorySectionReader,
+        ModuleReader,
+        Name,
+        NameSectionReader,
+        NamingReader,
+        OperatorsReader,
+        Reloc,
+        RelocSectionReader,
+        Section,
+        SectionReader,
+        TableSectionReader,
+        TypeSectionReader,
+    },
 };
-
-use crate::primitives::{
-    BinaryReaderError, CustomSectionKind, ExternalKind, FuncType, GlobalType,
-    ImportSectionEntryType, LinkingType, MemoryType, Naming, Operator, RelocType, Result,
-    SectionCode, TableType, Type,
-};
-
-use crate::readers::{
-    CodeSectionReader, Data, DataKind, DataSectionReader, Element, ElementItem, ElementItems,
-    ElementKind, ElementSectionReader, Export, ExportSectionReader, FunctionBody,
-    FunctionSectionReader, Global, GlobalSectionReader, Import, ImportSectionReader,
-    LinkingSectionReader, MemorySectionReader, ModuleReader, Name, NameSectionReader, NamingReader,
-    OperatorsReader, Reloc, RelocSectionReader, Section, SectionReader, TableSectionReader,
-    TypeSectionReader,
-};
-
-use crate::binary_reader::{BinaryReader, Range};
 
 const MAX_DATA_CHUNK_SIZE: usize = MAX_WASM_STRING_SIZE;
 

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -13,9 +13,7 @@
  * limitations under the License.
  */
 
-use std::error::Error;
-use std::fmt;
-use std::result;
+use std::{error::Error, fmt, result};
 
 #[derive(Debug, Clone)]
 pub struct BinaryReaderError {

--- a/src/readers/code_section.rs
+++ b/src/readers/code_section.rs
@@ -14,8 +14,15 @@
  */
 
 use super::{
-    BinaryReader, BinaryReaderError, OperatorsReader, Range, Result, SectionIteratorLimited,
-    SectionReader, SectionWithLimitedItems, Type,
+    BinaryReader,
+    BinaryReaderError,
+    OperatorsReader,
+    Range,
+    Result,
+    SectionIteratorLimited,
+    SectionReader,
+    SectionWithLimitedItems,
+    Type,
 };
 
 #[derive(Debug)]

--- a/src/readers/data_section.rs
+++ b/src/readers/data_section.rs
@@ -14,7 +14,12 @@
  */
 
 use super::{
-    BinaryReader, BinaryReaderError, InitExpr, Result, SectionIteratorLimited, SectionReader,
+    BinaryReader,
+    BinaryReaderError,
+    InitExpr,
+    Result,
+    SectionIteratorLimited,
+    SectionReader,
     SectionWithLimitedItems,
 };
 

--- a/src/readers/element_section.rs
+++ b/src/readers/element_section.rs
@@ -14,8 +14,14 @@
  */
 
 use super::{
-    BinaryReader, BinaryReaderError, InitExpr, Result, SectionIteratorLimited, SectionReader,
-    SectionWithLimitedItems, Type,
+    BinaryReader,
+    BinaryReaderError,
+    InitExpr,
+    Result,
+    SectionIteratorLimited,
+    SectionReader,
+    SectionWithLimitedItems,
+    Type,
 };
 use crate::{ExternalKind, Operator};
 

--- a/src/readers/export_section.rs
+++ b/src/readers/export_section.rs
@@ -14,7 +14,11 @@
  */
 
 use super::{
-    BinaryReader, ExternalKind, Result, SectionIteratorLimited, SectionReader,
+    BinaryReader,
+    ExternalKind,
+    Result,
+    SectionIteratorLimited,
+    SectionReader,
     SectionWithLimitedItems,
 };
 

--- a/src/readers/global_section.rs
+++ b/src/readers/global_section.rs
@@ -14,7 +14,12 @@
  */
 
 use super::{
-    BinaryReader, GlobalType, InitExpr, Result, SectionIteratorLimited, SectionReader,
+    BinaryReader,
+    GlobalType,
+    InitExpr,
+    Result,
+    SectionIteratorLimited,
+    SectionReader,
     SectionWithLimitedItems,
 };
 

--- a/src/readers/import_section.rs
+++ b/src/readers/import_section.rs
@@ -14,8 +14,13 @@
  */
 
 use super::{
-    BinaryReader, ExternalKind, ImportSectionEntryType, Result, SectionIteratorLimited,
-    SectionReader, SectionWithLimitedItems,
+    BinaryReader,
+    ExternalKind,
+    ImportSectionEntryType,
+    Result,
+    SectionIteratorLimited,
+    SectionReader,
+    SectionWithLimitedItems,
 };
 
 #[derive(Debug, Copy, Clone)]

--- a/src/readers/linking_section.rs
+++ b/src/readers/linking_section.rs
@@ -14,7 +14,11 @@
  */
 
 use super::{
-    BinaryReader, LinkingType, Result, SectionIteratorLimited, SectionReader,
+    BinaryReader,
+    LinkingType,
+    Result,
+    SectionIteratorLimited,
+    SectionReader,
     SectionWithLimitedItems,
 };
 

--- a/src/readers/memory_section.rs
+++ b/src/readers/memory_section.rs
@@ -14,7 +14,11 @@
  */
 
 use super::{
-    BinaryReader, MemoryType, Result, SectionIteratorLimited, SectionReader,
+    BinaryReader,
+    MemoryType,
+    Result,
+    SectionIteratorLimited,
+    SectionReader,
     SectionWithLimitedItems,
 };
 

--- a/src/readers/mod.rs
+++ b/src/readers/mod.rs
@@ -13,69 +13,69 @@
  * limitations under the License.
  */
 
-use super::{
-    BinaryReader, BinaryReaderError, CustomSectionKind, ExternalKind, FuncType, GlobalType,
-    ImportSectionEntryType, LinkingType, MemoryType, NameType, Naming, Operator, Range, RelocType,
-    Result, SectionCode, TableType, Type,
+pub use self::{
+    code_section::{CodeSectionReader, FunctionBody, LocalsReader},
+    data_section::{Data, DataKind, DataSectionReader},
+    element_section::{
+        Element,
+        ElementItem,
+        ElementItems,
+        ElementItemsReader,
+        ElementKind,
+        ElementSectionReader,
+    },
+    export_section::{Export, ExportSectionReader},
+    function_section::FunctionSectionReader,
+    global_section::{Global, GlobalSectionReader},
+    import_section::{Import, ImportSectionReader},
+    init_expr::InitExpr,
+    linking_section::LinkingSectionReader,
+    memory_section::MemorySectionReader,
+    module::{CustomSectionContent, ModuleReader, Section, SectionContent},
+    name_section::{FunctionName, LocalName, ModuleName, Name, NameSectionReader, NamingReader},
+    operators::OperatorsReader,
+    producers_section::{
+        ProducersField,
+        ProducersFieldValue,
+        ProducersFieldValuesReader,
+        ProducersSectionReader,
+    },
+    reloc_section::{Reloc, RelocSectionReader},
+    section_reader::{
+        SectionIterator,
+        SectionIteratorLimited,
+        SectionReader,
+        SectionWithLimitedItems,
+    },
+    table_section::TableSectionReader,
+    type_section::TypeSectionReader,
 };
-
-use super::SectionHeader;
-
-pub use self::code_section::CodeSectionReader;
-pub use self::code_section::FunctionBody;
-pub use self::code_section::LocalsReader;
-use self::data_count_section::read_data_count_section_content;
-pub use self::data_section::Data;
-pub use self::data_section::DataKind;
-pub use self::data_section::DataSectionReader;
-pub use self::element_section::Element;
-pub use self::element_section::ElementItem;
-pub use self::element_section::ElementItems;
-pub use self::element_section::ElementItemsReader;
-pub use self::element_section::ElementKind;
-pub use self::element_section::ElementSectionReader;
-pub use self::export_section::Export;
-pub use self::export_section::ExportSectionReader;
-pub use self::function_section::FunctionSectionReader;
-pub use self::global_section::Global;
-pub use self::global_section::GlobalSectionReader;
-pub use self::import_section::Import;
-pub use self::import_section::ImportSectionReader;
-pub use self::init_expr::InitExpr;
-pub use self::memory_section::MemorySectionReader;
-pub use self::module::CustomSectionContent;
-pub use self::module::ModuleReader;
-pub use self::module::Section;
-pub use self::module::SectionContent;
-use self::start_section::read_start_section_content;
-pub use self::table_section::TableSectionReader;
-pub use self::type_section::TypeSectionReader;
-
-pub use self::section_reader::SectionIterator;
-pub use self::section_reader::SectionIteratorLimited;
-pub use self::section_reader::SectionReader;
-pub use self::section_reader::SectionWithLimitedItems;
-
-pub use self::name_section::FunctionName;
-pub use self::name_section::LocalName;
-pub use self::name_section::ModuleName;
-pub use self::name_section::Name;
-pub use self::name_section::NameSectionReader;
-pub use self::name_section::NamingReader;
-
-pub use self::producers_section::ProducersField;
-pub use self::producers_section::ProducersFieldValue;
-pub use self::producers_section::ProducersFieldValuesReader;
-pub use self::producers_section::ProducersSectionReader;
-
-pub use self::linking_section::LinkingSectionReader;
-
-pub use self::reloc_section::Reloc;
-pub use self::reloc_section::RelocSectionReader;
-
-use self::sourcemappingurl_section::read_sourcemappingurl_section_content;
-
-pub use self::operators::OperatorsReader;
+use self::{
+    data_count_section::read_data_count_section_content,
+    sourcemappingurl_section::read_sourcemappingurl_section_content,
+    start_section::read_start_section_content,
+};
+use super::{
+    BinaryReader,
+    BinaryReaderError,
+    CustomSectionKind,
+    ExternalKind,
+    FuncType,
+    GlobalType,
+    ImportSectionEntryType,
+    LinkingType,
+    MemoryType,
+    NameType,
+    Naming,
+    Operator,
+    Range,
+    RelocType,
+    Result,
+    SectionCode,
+    SectionHeader,
+    TableType,
+    Type,
+};
 
 mod code_section;
 mod data_count_section;

--- a/src/readers/module.rs
+++ b/src/readers/module.rs
@@ -14,15 +14,30 @@
  */
 
 use super::{
-    BinaryReader, BinaryReaderError, CustomSectionKind, Range, Result, SectionCode, SectionHeader,
-};
-
-use super::{
-    read_data_count_section_content, read_sourcemappingurl_section_content,
-    read_start_section_content, CodeSectionReader, DataSectionReader, ElementSectionReader,
-    ExportSectionReader, FunctionSectionReader, GlobalSectionReader, ImportSectionReader,
-    LinkingSectionReader, MemorySectionReader, NameSectionReader, ProducersSectionReader,
-    RelocSectionReader, TableSectionReader, TypeSectionReader,
+    read_data_count_section_content,
+    read_sourcemappingurl_section_content,
+    read_start_section_content,
+    BinaryReader,
+    BinaryReaderError,
+    CodeSectionReader,
+    CustomSectionKind,
+    DataSectionReader,
+    ElementSectionReader,
+    ExportSectionReader,
+    FunctionSectionReader,
+    GlobalSectionReader,
+    ImportSectionReader,
+    LinkingSectionReader,
+    MemorySectionReader,
+    NameSectionReader,
+    ProducersSectionReader,
+    Range,
+    RelocSectionReader,
+    Result,
+    SectionCode,
+    SectionHeader,
+    TableSectionReader,
+    TypeSectionReader,
 };
 
 #[derive(Debug)]

--- a/src/readers/name_section.rs
+++ b/src/readers/name_section.rs
@@ -14,7 +14,13 @@
  */
 
 use super::{
-    BinaryReader, BinaryReaderError, NameType, Naming, Result, SectionIterator, SectionReader,
+    BinaryReader,
+    BinaryReaderError,
+    NameType,
+    Naming,
+    Result,
+    SectionIterator,
+    SectionReader,
 };
 
 #[derive(Debug, Copy, Clone)]

--- a/src/readers/reloc_section.rs
+++ b/src/readers/reloc_section.rs
@@ -14,7 +14,12 @@
  */
 
 use super::{
-    BinaryReader, RelocType, Result, SectionCode, SectionIteratorLimited, SectionReader,
+    BinaryReader,
+    RelocType,
+    Result,
+    SectionCode,
+    SectionIteratorLimited,
+    SectionReader,
     SectionWithLimitedItems,
 };
 

--- a/src/readers/table_section.rs
+++ b/src/readers/table_section.rs
@@ -14,7 +14,12 @@
  */
 
 use super::{
-    BinaryReader, Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems, TableType,
+    BinaryReader,
+    Result,
+    SectionIteratorLimited,
+    SectionReader,
+    SectionWithLimitedItems,
+    TableType,
 };
 
 pub struct TableSectionReader<'a> {

--- a/src/readers/type_section.rs
+++ b/src/readers/type_section.rs
@@ -14,7 +14,12 @@
  */
 
 use super::{
-    BinaryReader, FuncType, Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems,
+    BinaryReader,
+    FuncType,
+    Result,
+    SectionIteratorLimited,
+    SectionReader,
+    SectionWithLimitedItems,
 };
 
 pub struct TypeSectionReader<'a> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -15,11 +15,11 @@
 
 #[cfg(test)]
 mod simple_tests {
-    use crate::parser::{Parser, ParserInput, ParserState, WasmDecoder};
-    use crate::primitives::{Operator, SectionCode};
-    use std::fs::File;
-    use std::io::prelude::*;
-    use std::path::PathBuf;
+    use crate::{
+        parser::{Parser, ParserInput, ParserState, WasmDecoder},
+        primitives::{Operator, SectionCode},
+    };
+    use std::{fs::File, io::prelude::*, path::PathBuf};
 
     fn read_file_data(path: &PathBuf) -> Vec<u8> {
         println!("Parsing {:?}", path);

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -13,29 +13,49 @@
  * limitations under the License.
  */
 
-use std::collections::HashSet;
-use std::result;
-use std::str;
-
-use crate::limits::{
-    MAX_WASM_FUNCTIONS, MAX_WASM_FUNCTION_LOCALS, MAX_WASM_GLOBALS, MAX_WASM_MEMORIES,
-    MAX_WASM_MEMORY_PAGES, MAX_WASM_TABLES, MAX_WASM_TYPES,
+use crate::{
+    binary_reader::BinaryReader,
+    limits::{
+        MAX_WASM_FUNCTIONS,
+        MAX_WASM_FUNCTION_LOCALS,
+        MAX_WASM_GLOBALS,
+        MAX_WASM_MEMORIES,
+        MAX_WASM_MEMORY_PAGES,
+        MAX_WASM_TABLES,
+        MAX_WASM_TYPES,
+    },
+    operators_validator::{
+        check_value_type,
+        FunctionEnd,
+        OperatorValidator,
+        OperatorValidatorConfig,
+        OperatorValidatorError,
+        DEFAULT_OPERATOR_VALIDATOR_CONFIG,
+    },
+    parser::{Parser, ParserInput, ParserState, WasmDecoder},
+    primitives::{
+        BinaryReaderError,
+        ExternalKind,
+        FuncType,
+        GlobalType,
+        ImportSectionEntryType,
+        MemoryType,
+        Operator,
+        ResizableLimits,
+        Result,
+        SectionCode,
+        TableType,
+        Type,
+    },
+    ElemSectionEntryTable,
+    ElementItem,
+    WasmFuncType,
+    WasmGlobalType,
+    WasmMemoryType,
+    WasmModuleResources,
+    WasmTableType,
 };
-
-use crate::binary_reader::BinaryReader;
-
-use crate::primitives::{
-    BinaryReaderError, ExternalKind, FuncType, GlobalType, ImportSectionEntryType, MemoryType,
-    Operator, ResizableLimits, Result, SectionCode, TableType, Type,
-};
-
-use crate::operators_validator::{
-    check_value_type, FunctionEnd, OperatorValidator, OperatorValidatorConfig,
-    OperatorValidatorError, DEFAULT_OPERATOR_VALIDATOR_CONFIG,
-};
-use crate::parser::{Parser, ParserInput, ParserState, WasmDecoder};
-use crate::{ElemSectionEntryTable, ElementItem};
-use crate::{WasmFuncType, WasmGlobalType, WasmMemoryType, WasmModuleResources, WasmTableType};
+use std::{collections::HashSet, result, str};
 
 use crate::readers::FunctionBody;
 

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -10,12 +10,20 @@
 
 use anyhow::{bail, Context, Result};
 use rayon::prelude::*;
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::str;
-use wasmparser::{BinaryReaderError, OperatorValidatorConfig};
-use wasmparser::{Parser, ParserState, WasmDecoder};
-use wasmparser::{ValidatingParser, ValidatingParserConfig};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    str,
+};
+use wasmparser::{
+    BinaryReaderError,
+    OperatorValidatorConfig,
+    Parser,
+    ParserState,
+    ValidatingParser,
+    ValidatingParserConfig,
+    WasmDecoder,
+};
 
 #[derive(PartialEq, PartialOrd, Eq, Ord)]
 enum Test {


### PR DESCRIPTION
This PR tries to experiment and introduce nested imports into `wasmparser` that are less verbose than what we currently are using while keeping them readable unlike the normal situation with `rustfmt` standard config.

Note that this apparently uses the (still unstable) `imports-layout` `rustfmt` config.
Please tell me if you like or dislike this approach of derivating from the standard `rustfmt` config a bit.

Since the changes introduced by this PR are not in any way important feel free to close this PR if its approach is inacceptable for `wasmparser`.

Also note that CI is failing since I only converted `lib.rs` and the `readers/mod.rs` files as an initial show case. If this approach is accepted the rest of the crate is going to be converted as well before merging this PR.