### PR TITLE
Fix nearly all clippy lints

### DIFF
--- a/src/binary_reader.rs
+++ b/src/binary_reader.rs
@@ -39,7 +39,7 @@ fn is_name_prefix(name: &str, prefix: &'static str) -> bool {
     name.starts_with(prefix)
 }
 
-const WASM_MAGIC_NUMBER: &'static [u8; 4] = b"\0asm";
+const WASM_MAGIC_NUMBER: &[u8; 4] = b"\0asm";
 const WASM_EXPERIMENTAL_VERSION: u32 = 0xd;
 const WASM_SUPPORTED_VERSION: u32 = 0x1;
 

--- a/src/operators_validator.rs
+++ b/src/operators_validator.rs
@@ -490,7 +490,7 @@ impl OperatorValidator {
 
     fn check_memarg(
         &self,
-        memarg: &MemoryImmediate,
+        memarg: MemoryImmediate,
         max_align: u32,
         resources: &dyn WasmModuleResources,
     ) -> OperatorValidatorResult<()> {
@@ -546,7 +546,7 @@ impl OperatorValidator {
 
     fn check_shared_memarg_wo_align(
         &self,
-        _: &MemoryImmediate,
+        _: MemoryImmediate,
         resources: &dyn WasmModuleResources,
     ) -> OperatorValidatorResult<()> {
         self.check_shared_memory_index(0, resources)?;
@@ -813,121 +813,121 @@ impl OperatorValidator {
                 self.check_operands_1(ty.content_type)?;
                 self.func_state.change_frame(1)?;
             }
-            Operator::I32Load { ref memarg } => {
+            Operator::I32Load { memarg } => {
                 self.check_memarg(memarg, 2, resources)?;
                 self.check_operands_1(Type::I32)?;
                 self.func_state.change_frame_with_type(1, Type::I32)?;
             }
-            Operator::I64Load { ref memarg } => {
+            Operator::I64Load { memarg } => {
                 self.check_memarg(memarg, 3, resources)?;
                 self.check_operands_1(Type::I32)?;
                 self.func_state.change_frame_with_type(1, Type::I64)?;
             }
-            Operator::F32Load { ref memarg } => {
+            Operator::F32Load { memarg } => {
                 self.check_non_deterministic_enabled()?;
                 self.check_memarg(memarg, 2, resources)?;
                 self.check_operands_1(Type::I32)?;
                 self.func_state.change_frame_with_type(1, Type::F32)?;
             }
-            Operator::F64Load { ref memarg } => {
+            Operator::F64Load { memarg } => {
                 self.check_non_deterministic_enabled()?;
                 self.check_memarg(memarg, 3, resources)?;
                 self.check_operands_1(Type::I32)?;
                 self.func_state.change_frame_with_type(1, Type::F64)?;
             }
-            Operator::I32Load8S { ref memarg } => {
+            Operator::I32Load8S { memarg } => {
                 self.check_memarg(memarg, 0, resources)?;
                 self.check_operands_1(Type::I32)?;
                 self.func_state.change_frame_with_type(1, Type::I32)?;
             }
-            Operator::I32Load8U { ref memarg } => {
+            Operator::I32Load8U { memarg } => {
                 self.check_memarg(memarg, 0, resources)?;
                 self.check_operands_1(Type::I32)?;
                 self.func_state.change_frame_with_type(1, Type::I32)?;
             }
-            Operator::I32Load16S { ref memarg } => {
+            Operator::I32Load16S { memarg } => {
                 self.check_memarg(memarg, 1, resources)?;
                 self.check_operands_1(Type::I32)?;
                 self.func_state.change_frame_with_type(1, Type::I32)?;
             }
-            Operator::I32Load16U { ref memarg } => {
+            Operator::I32Load16U { memarg } => {
                 self.check_memarg(memarg, 1, resources)?;
                 self.check_operands_1(Type::I32)?;
                 self.func_state.change_frame_with_type(1, Type::I32)?;
             }
-            Operator::I64Load8S { ref memarg } => {
+            Operator::I64Load8S { memarg } => {
                 self.check_memarg(memarg, 0, resources)?;
                 self.check_operands_1(Type::I32)?;
                 self.func_state.change_frame_with_type(1, Type::I64)?;
             }
-            Operator::I64Load8U { ref memarg } => {
+            Operator::I64Load8U { memarg } => {
                 self.check_memarg(memarg, 0, resources)?;
                 self.check_operands_1(Type::I32)?;
                 self.func_state.change_frame_with_type(1, Type::I64)?;
             }
-            Operator::I64Load16S { ref memarg } => {
+            Operator::I64Load16S { memarg } => {
                 self.check_memarg(memarg, 1, resources)?;
                 self.check_operands_1(Type::I32)?;
                 self.func_state.change_frame_with_type(1, Type::I64)?;
             }
-            Operator::I64Load16U { ref memarg } => {
+            Operator::I64Load16U { memarg } => {
                 self.check_memarg(memarg, 1, resources)?;
                 self.check_operands_1(Type::I32)?;
                 self.func_state.change_frame_with_type(1, Type::I64)?;
             }
-            Operator::I64Load32S { ref memarg } => {
+            Operator::I64Load32S { memarg } => {
                 self.check_memarg(memarg, 2, resources)?;
                 self.check_operands_1(Type::I32)?;
                 self.func_state.change_frame_with_type(1, Type::I64)?;
             }
-            Operator::I64Load32U { ref memarg } => {
+            Operator::I64Load32U { memarg } => {
                 self.check_memarg(memarg, 2, resources)?;
                 self.check_operands_1(Type::I32)?;
                 self.func_state.change_frame_with_type(1, Type::I64)?;
             }
-            Operator::I32Store { ref memarg } => {
+            Operator::I32Store { memarg } => {
                 self.check_memarg(memarg, 2, resources)?;
                 self.check_operands_2(Type::I32, Type::I32)?;
                 self.func_state.change_frame(2)?;
             }
-            Operator::I64Store { ref memarg } => {
+            Operator::I64Store { memarg } => {
                 self.check_memarg(memarg, 3, resources)?;
                 self.check_operands_2(Type::I32, Type::I64)?;
                 self.func_state.change_frame(2)?;
             }
-            Operator::F32Store { ref memarg } => {
+            Operator::F32Store { memarg } => {
                 self.check_non_deterministic_enabled()?;
                 self.check_memarg(memarg, 2, resources)?;
                 self.check_operands_2(Type::I32, Type::F32)?;
                 self.func_state.change_frame(2)?;
             }
-            Operator::F64Store { ref memarg } => {
+            Operator::F64Store { memarg } => {
                 self.check_non_deterministic_enabled()?;
                 self.check_memarg(memarg, 3, resources)?;
                 self.check_operands_2(Type::I32, Type::F64)?;
                 self.func_state.change_frame(2)?;
             }
-            Operator::I32Store8 { ref memarg } => {
+            Operator::I32Store8 { memarg } => {
                 self.check_memarg(memarg, 0, resources)?;
                 self.check_operands_2(Type::I32, Type::I32)?;
                 self.func_state.change_frame(2)?;
             }
-            Operator::I32Store16 { ref memarg } => {
+            Operator::I32Store16 { memarg } => {
                 self.check_memarg(memarg, 1, resources)?;
                 self.check_operands_2(Type::I32, Type::I32)?;
                 self.func_state.change_frame(2)?;
             }
-            Operator::I64Store8 { ref memarg } => {
+            Operator::I64Store8 { memarg } => {
                 self.check_memarg(memarg, 0, resources)?;
                 self.check_operands_2(Type::I32, Type::I64)?;
                 self.func_state.change_frame(2)?;
             }
-            Operator::I64Store16 { ref memarg } => {
+            Operator::I64Store16 { memarg } => {
                 self.check_memarg(memarg, 1, resources)?;
                 self.check_operands_2(Type::I32, Type::I64)?;
                 self.func_state.change_frame(2)?;
             }
-            Operator::I64Store32 { ref memarg } => {
+            Operator::I64Store32 { memarg } => {
                 self.check_memarg(memarg, 2, resources)?;
                 self.check_operands_2(Type::I32, Type::I64)?;
                 self.func_state.change_frame(2)?;
@@ -1195,132 +1195,132 @@ impl OperatorValidator {
                 self.func_state.change_frame_with_type(1, Type::I64)?;
             }
 
-            Operator::I32AtomicLoad { ref memarg }
-            | Operator::I32AtomicLoad16U { ref memarg }
-            | Operator::I32AtomicLoad8U { ref memarg } => {
+            Operator::I32AtomicLoad { memarg }
+            | Operator::I32AtomicLoad16U { memarg }
+            | Operator::I32AtomicLoad8U { memarg } => {
                 self.check_threads_enabled()?;
                 self.check_shared_memarg_wo_align(memarg, resources)?;
                 self.check_operands_1(Type::I32)?;
                 self.func_state.change_frame_with_type(1, Type::I32)?;
             }
-            Operator::I64AtomicLoad { ref memarg }
-            | Operator::I64AtomicLoad32U { ref memarg }
-            | Operator::I64AtomicLoad16U { ref memarg }
-            | Operator::I64AtomicLoad8U { ref memarg } => {
+            Operator::I64AtomicLoad { memarg }
+            | Operator::I64AtomicLoad32U { memarg }
+            | Operator::I64AtomicLoad16U { memarg }
+            | Operator::I64AtomicLoad8U { memarg } => {
                 self.check_threads_enabled()?;
                 self.check_shared_memarg_wo_align(memarg, resources)?;
                 self.check_operands_1(Type::I32)?;
                 self.func_state.change_frame_with_type(1, Type::I64)?;
             }
-            Operator::I32AtomicStore { ref memarg }
-            | Operator::I32AtomicStore16 { ref memarg }
-            | Operator::I32AtomicStore8 { ref memarg } => {
+            Operator::I32AtomicStore { memarg }
+            | Operator::I32AtomicStore16 { memarg }
+            | Operator::I32AtomicStore8 { memarg } => {
                 self.check_threads_enabled()?;
                 self.check_shared_memarg_wo_align(memarg, resources)?;
                 self.check_operands_2(Type::I32, Type::I32)?;
                 self.func_state.change_frame(2)?;
             }
-            Operator::I64AtomicStore { ref memarg }
-            | Operator::I64AtomicStore32 { ref memarg }
-            | Operator::I64AtomicStore16 { ref memarg }
-            | Operator::I64AtomicStore8 { ref memarg } => {
+            Operator::I64AtomicStore { memarg }
+            | Operator::I64AtomicStore32 { memarg }
+            | Operator::I64AtomicStore16 { memarg }
+            | Operator::I64AtomicStore8 { memarg } => {
                 self.check_threads_enabled()?;
                 self.check_shared_memarg_wo_align(memarg, resources)?;
                 self.check_operands_2(Type::I32, Type::I64)?;
                 self.func_state.change_frame(2)?;
             }
-            Operator::I32AtomicRmwAdd { ref memarg }
-            | Operator::I32AtomicRmwSub { ref memarg }
-            | Operator::I32AtomicRmwAnd { ref memarg }
-            | Operator::I32AtomicRmwOr { ref memarg }
-            | Operator::I32AtomicRmwXor { ref memarg }
-            | Operator::I32AtomicRmw16AddU { ref memarg }
-            | Operator::I32AtomicRmw16SubU { ref memarg }
-            | Operator::I32AtomicRmw16AndU { ref memarg }
-            | Operator::I32AtomicRmw16OrU { ref memarg }
-            | Operator::I32AtomicRmw16XorU { ref memarg }
-            | Operator::I32AtomicRmw8AddU { ref memarg }
-            | Operator::I32AtomicRmw8SubU { ref memarg }
-            | Operator::I32AtomicRmw8AndU { ref memarg }
-            | Operator::I32AtomicRmw8OrU { ref memarg }
-            | Operator::I32AtomicRmw8XorU { ref memarg } => {
+            Operator::I32AtomicRmwAdd { memarg }
+            | Operator::I32AtomicRmwSub { memarg }
+            | Operator::I32AtomicRmwAnd { memarg }
+            | Operator::I32AtomicRmwOr { memarg }
+            | Operator::I32AtomicRmwXor { memarg }
+            | Operator::I32AtomicRmw16AddU { memarg }
+            | Operator::I32AtomicRmw16SubU { memarg }
+            | Operator::I32AtomicRmw16AndU { memarg }
+            | Operator::I32AtomicRmw16OrU { memarg }
+            | Operator::I32AtomicRmw16XorU { memarg }
+            | Operator::I32AtomicRmw8AddU { memarg }
+            | Operator::I32AtomicRmw8SubU { memarg }
+            | Operator::I32AtomicRmw8AndU { memarg }
+            | Operator::I32AtomicRmw8OrU { memarg }
+            | Operator::I32AtomicRmw8XorU { memarg } => {
                 self.check_threads_enabled()?;
                 self.check_shared_memarg_wo_align(memarg, resources)?;
                 self.check_operands_2(Type::I32, Type::I32)?;
                 self.func_state.change_frame_with_type(2, Type::I32)?;
             }
-            Operator::I64AtomicRmwAdd { ref memarg }
-            | Operator::I64AtomicRmwSub { ref memarg }
-            | Operator::I64AtomicRmwAnd { ref memarg }
-            | Operator::I64AtomicRmwOr { ref memarg }
-            | Operator::I64AtomicRmwXor { ref memarg }
-            | Operator::I64AtomicRmw32AddU { ref memarg }
-            | Operator::I64AtomicRmw32SubU { ref memarg }
-            | Operator::I64AtomicRmw32AndU { ref memarg }
-            | Operator::I64AtomicRmw32OrU { ref memarg }
-            | Operator::I64AtomicRmw32XorU { ref memarg }
-            | Operator::I64AtomicRmw16AddU { ref memarg }
-            | Operator::I64AtomicRmw16SubU { ref memarg }
-            | Operator::I64AtomicRmw16AndU { ref memarg }
-            | Operator::I64AtomicRmw16OrU { ref memarg }
-            | Operator::I64AtomicRmw16XorU { ref memarg }
-            | Operator::I64AtomicRmw8AddU { ref memarg }
-            | Operator::I64AtomicRmw8SubU { ref memarg }
-            | Operator::I64AtomicRmw8AndU { ref memarg }
-            | Operator::I64AtomicRmw8OrU { ref memarg }
-            | Operator::I64AtomicRmw8XorU { ref memarg } => {
+            Operator::I64AtomicRmwAdd { memarg }
+            | Operator::I64AtomicRmwSub { memarg }
+            | Operator::I64AtomicRmwAnd { memarg }
+            | Operator::I64AtomicRmwOr { memarg }
+            | Operator::I64AtomicRmwXor { memarg }
+            | Operator::I64AtomicRmw32AddU { memarg }
+            | Operator::I64AtomicRmw32SubU { memarg }
+            | Operator::I64AtomicRmw32AndU { memarg }
+            | Operator::I64AtomicRmw32OrU { memarg }
+            | Operator::I64AtomicRmw32XorU { memarg }
+            | Operator::I64AtomicRmw16AddU { memarg }
+            | Operator::I64AtomicRmw16SubU { memarg }
+            | Operator::I64AtomicRmw16AndU { memarg }
+            | Operator::I64AtomicRmw16OrU { memarg }
+            | Operator::I64AtomicRmw16XorU { memarg }
+            | Operator::I64AtomicRmw8AddU { memarg }
+            | Operator::I64AtomicRmw8SubU { memarg }
+            | Operator::I64AtomicRmw8AndU { memarg }
+            | Operator::I64AtomicRmw8OrU { memarg }
+            | Operator::I64AtomicRmw8XorU { memarg } => {
                 self.check_threads_enabled()?;
                 self.check_shared_memarg_wo_align(memarg, resources)?;
                 self.check_operands_2(Type::I32, Type::I64)?;
                 self.func_state.change_frame_with_type(2, Type::I64)?;
             }
-            Operator::I32AtomicRmwXchg { ref memarg }
-            | Operator::I32AtomicRmw16XchgU { ref memarg }
-            | Operator::I32AtomicRmw8XchgU { ref memarg } => {
+            Operator::I32AtomicRmwXchg { memarg }
+            | Operator::I32AtomicRmw16XchgU { memarg }
+            | Operator::I32AtomicRmw8XchgU { memarg } => {
                 self.check_threads_enabled()?;
                 self.check_shared_memarg_wo_align(memarg, resources)?;
                 self.check_operands_2(Type::I32, Type::I32)?;
                 self.func_state.change_frame_with_type(2, Type::I32)?;
             }
-            Operator::I32AtomicRmwCmpxchg { ref memarg }
-            | Operator::I32AtomicRmw16CmpxchgU { ref memarg }
-            | Operator::I32AtomicRmw8CmpxchgU { ref memarg } => {
+            Operator::I32AtomicRmwCmpxchg { memarg }
+            | Operator::I32AtomicRmw16CmpxchgU { memarg }
+            | Operator::I32AtomicRmw8CmpxchgU { memarg } => {
                 self.check_threads_enabled()?;
                 self.check_shared_memarg_wo_align(memarg, resources)?;
                 self.check_operands(&[Type::I32, Type::I32, Type::I32])?;
                 self.func_state.change_frame_with_type(3, Type::I32)?;
             }
-            Operator::I64AtomicRmwXchg { ref memarg }
-            | Operator::I64AtomicRmw32XchgU { ref memarg }
-            | Operator::I64AtomicRmw16XchgU { ref memarg }
-            | Operator::I64AtomicRmw8XchgU { ref memarg } => {
+            Operator::I64AtomicRmwXchg { memarg }
+            | Operator::I64AtomicRmw32XchgU { memarg }
+            | Operator::I64AtomicRmw16XchgU { memarg }
+            | Operator::I64AtomicRmw8XchgU { memarg } => {
                 self.check_threads_enabled()?;
                 self.check_shared_memarg_wo_align(memarg, resources)?;
                 self.check_operands_2(Type::I32, Type::I64)?;
                 self.func_state.change_frame_with_type(2, Type::I64)?;
             }
-            Operator::I64AtomicRmwCmpxchg { ref memarg }
-            | Operator::I64AtomicRmw32CmpxchgU { ref memarg }
-            | Operator::I64AtomicRmw16CmpxchgU { ref memarg }
-            | Operator::I64AtomicRmw8CmpxchgU { ref memarg } => {
+            Operator::I64AtomicRmwCmpxchg { memarg }
+            | Operator::I64AtomicRmw32CmpxchgU { memarg }
+            | Operator::I64AtomicRmw16CmpxchgU { memarg }
+            | Operator::I64AtomicRmw8CmpxchgU { memarg } => {
                 self.check_threads_enabled()?;
                 self.check_shared_memarg_wo_align(memarg, resources)?;
                 self.check_operands(&[Type::I32, Type::I64, Type::I64])?;
                 self.func_state.change_frame_with_type(3, Type::I64)?;
             }
-            Operator::AtomicNotify { ref memarg } => {
+            Operator::AtomicNotify { memarg } => {
                 self.check_threads_enabled()?;
                 self.check_shared_memarg_wo_align(memarg, resources)?;
                 self.check_operands_2(Type::I32, Type::I32)?;
                 self.func_state.change_frame_with_type(2, Type::I32)?;
             }
-            Operator::I32AtomicWait { ref memarg } => {
+            Operator::I32AtomicWait { memarg } => {
                 self.check_threads_enabled()?;
                 self.check_shared_memarg_wo_align(memarg, resources)?;
                 self.check_operands(&[Type::I32, Type::I32, Type::I64])?;
                 self.func_state.change_frame_with_type(3, Type::I32)?;
             }
-            Operator::I64AtomicWait { ref memarg } => {
+            Operator::I64AtomicWait { memarg } => {
                 self.check_threads_enabled()?;
                 self.check_shared_memarg_wo_align(memarg, resources)?;
                 self.check_operands(&[Type::I32, Type::I64, Type::I64])?;
@@ -1348,13 +1348,13 @@ impl OperatorValidator {
                 }
                 self.func_state.change_frame_with_type(0, Type::AnyFunc)?;
             }
-            Operator::V128Load { ref memarg } => {
+            Operator::V128Load { memarg } => {
                 self.check_simd_enabled()?;
                 self.check_memarg(memarg, 4, resources)?;
                 self.check_operands_1(Type::I32)?;
                 self.func_state.change_frame_with_type(1, Type::V128)?;
             }
-            Operator::V128Store { ref memarg } => {
+            Operator::V128Store { memarg } => {
                 self.check_simd_enabled()?;
                 self.check_memarg(memarg, 4, resources)?;
                 self.check_operands_2(Type::I32, Type::V128)?;
@@ -1637,31 +1637,31 @@ impl OperatorValidator {
                 }
                 self.func_state.change_frame_with_type(2, Type::V128)?;
             }
-            Operator::V8x16LoadSplat { ref memarg } => {
+            Operator::V8x16LoadSplat { memarg } => {
                 self.check_simd_enabled()?;
                 self.check_memarg(memarg, 0, resources)?;
                 self.check_operands_1(Type::I32)?;
                 self.func_state.change_frame_with_type(1, Type::V128)?;
             }
-            Operator::V16x8LoadSplat { ref memarg } => {
+            Operator::V16x8LoadSplat { memarg } => {
                 self.check_simd_enabled()?;
                 self.check_memarg(memarg, 1, resources)?;
                 self.check_operands_1(Type::I32)?;
                 self.func_state.change_frame_with_type(1, Type::V128)?;
             }
-            Operator::V32x4LoadSplat { ref memarg } => {
+            Operator::V32x4LoadSplat { memarg } => {
                 self.check_simd_enabled()?;
                 self.check_memarg(memarg, 2, resources)?;
                 self.check_operands_1(Type::I32)?;
                 self.func_state.change_frame_with_type(1, Type::V128)?;
             }
-            Operator::V64x2LoadSplat { ref memarg }
-            | Operator::I16x8Load8x8S { ref memarg }
-            | Operator::I16x8Load8x8U { ref memarg }
-            | Operator::I32x4Load16x4S { ref memarg }
-            | Operator::I32x4Load16x4U { ref memarg }
-            | Operator::I64x2Load32x2S { ref memarg }
-            | Operator::I64x2Load32x2U { ref memarg } => {
+            Operator::V64x2LoadSplat { memarg }
+            | Operator::I16x8Load8x8S { memarg }
+            | Operator::I16x8Load8x8U { memarg }
+            | Operator::I32x4Load16x4S { memarg }
+            | Operator::I32x4Load16x4U { memarg }
+            | Operator::I64x2Load32x2S { memarg }
+            | Operator::I64x2Load32x2U { memarg } => {
                 self.check_simd_enabled()?;
                 self.check_memarg(memarg, 3, resources)?;
                 self.check_operands_1(Type::I32)?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -925,9 +925,7 @@ impl<'a> Parser<'a> {
                 table: ElemSectionEntryTable::Active(_),
                 ..
             } => self.read_init_expression_body(InitExpressionContinuationSection::Element),
-            ParserState::BeginElementSectionEntry { table: _, .. } => {
-                self.read_element_entry_body()?
-            }
+            ParserState::BeginElementSectionEntry { .. } => self.read_element_entry_body()?,
             ParserState::BeginInitExpressionBody | ParserState::InitExpressionOperator(_) => {
                 self.read_init_expression_operator()?
             }

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -84,7 +84,7 @@ pub enum Type {
 }
 
 impl Type {
-    pub(crate) fn is_valid_for_old_select(&self) -> bool {
+    pub(crate) fn is_valid_for_old_select(self) -> bool {
         match self {
             Type::I32 | Type::I64 | Type::F32 | Type::F64 => true,
             _ => false,

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -536,13 +536,9 @@ impl<'a> ValidatingParser<'a> {
                         self.set_validation_error("element_type != table type");
                         return;
                     }
-                    if !self.config.operator_config.enable_reference_types {
-                        if ty != Type::AnyFunc {
-                            self.set_validation_error(
-                                "element_type != anyfunc is not supported yet",
-                            );
-                            return;
-                        }
+                    if !self.config.operator_config.enable_reference_types && ty != Type::AnyFunc {
+                        self.set_validation_error("element_type != anyfunc is not supported yet");
+                        return;
                     }
                     self.init_expression_state = Some(InitExpressionState {
                         ty: Type::I32,


### PR DESCRIPTION
tldr; Performance improvements! :)

I ran `cargo +stable clippy` and found a few issues:

```
warning: Constants have by default a `'static` lifetime
  --> src/binary_reader.rs:42:27
   |
42 | const WASM_MAGIC_NUMBER: &'static [u8; 4] = b"\0asm";
   |                          -^^^^^^^-------- help: consider removing `'static`: `&[u8; 4]`
   |
   = note: `#[warn(clippy::redundant_static_lifetimes)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_static_lifetimes

warning: All the struct fields are matched to a wildcard pattern, consider using `..`.
   --> src/parser.rs:928:13
    |
928 |             ParserState::BeginElementSectionEntry { table: _, .. } => {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(clippy::unneeded_field_pattern)]` on by default
    = help: Try with `BeginElementSectionEntry { .. }` instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unneeded_field_pattern

warning: this if statement can be collapsed
   --> src/validator.rs:539:21
    |
539 | /                     if !self.config.operator_config.enable_reference_types {
540 | |                         if ty != Type::AnyFunc {
541 | |                             self.set_validation_error(
542 | |                                 "element_type != anyfunc is not supported yet",
...   |
545 | |                         }
546 | |                     }
    | |_____________________^
    |
    = note: `#[warn(clippy::collapsible_if)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_if
help: try
    |
539 |                     if !self.config.operator_config.enable_reference_types && ty != Type::AnyFunc {
540 |     self.set_validation_error(
541 |         "element_type != anyfunc is not supported yet",
542 |     );
543 |     return;
544 | }
    |

warning: this argument (8 byte) is passed by reference, but would be more efficient if passed by value (limit: 8 byte)
   --> src/operators_validator.rs:493:17
    |
493 |         memarg: &MemoryImmediate,
    |                 ^^^^^^^^^^^^^^^^ help: consider passing by value instead: `MemoryImmediate`
    |
    = note: `#[warn(clippy::trivially_copy_pass_by_ref)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref

warning: this argument (8 byte) is passed by reference, but would be more efficient if passed by value (limit: 8 byte)
   --> src/operators_validator.rs:549:12
    |
549 |         _: &MemoryImmediate,
    |            ^^^^^^^^^^^^^^^^ help: consider passing by value instead: `MemoryImmediate`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref

warning: this argument (1 byte) is passed by reference, but would be more efficient if passed by value (limit: 8 byte)
  --> src/primitives.rs:87:43
   |
87 |     pub(crate) fn is_valid_for_old_select(&self) -> bool {
   |                                           ^^^^^ help: consider passing by value instead: `self`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref

warning: the function has a cognitive complexity of (29/25)
   --> src/validator.rs:414:5
    |
414 | /     fn process_state(&mut self) {
415 | |         match *self.parser.last_state() {
416 | |             ParserState::BeginWasm { version } => {
417 | |                 if version != 1 {
...   |
632 | |         };
633 | |     }
    | |_____^
    |
    = note: `#[warn(clippy::cognitive_complexity)]` on by default
    = help: you could split it up into multiple smaller functions
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cognitive_complexity
```

This PR fixes all of the above except the cognitive complexity one since I don't think it is a real issue to understand the function. So I'd rather flag it to `clippy` as O.K. in this case.

As you can see there have been a few performance related fixes according to `clippy`.
And in fact I am able to see some more or less significant speed ups:

`master`

```
     Running target/release/deps/benchmark-9cda06f706570dbc
it works benchmark      time:   [1.8502 us 1.9217 us 2.0109 us]                               
                        change: [-7.2379% -0.5249% +6.4208%] (p = 0.88 > 0.05)
                        No change in performance detected.
Found 16 outliers among 100 measurements (16.00%)
  4 (4.00%) high mild
  12 (12.00%) high severe

validator no fails benchmark                                                                             
                        time:   [5.7879 us 6.0434 us 6.3347 us]
                        change: [-2.5549% +3.6310% +10.975%] (p = 0.28 > 0.05)
                        No change in performance detected.
Found 17 outliers among 100 measurements (17.00%)
  2 (2.00%) high mild
  15 (15.00%) high severe

validate benchmark      time:   [5.6093 us 5.7909 us 6.0077 us]                                
                        change: [+0.1006% +3.7302% +7.9364%] (p = 0.08 > 0.05)
                        No change in performance detected.
Found 13 outliers among 100 measurements (13.00%)
  2 (2.00%) high mild
  11 (11.00%) high severe
```

`fix-clippy-lints`:

```
     Running target/release/deps/benchmark-9cda06f706570dbc
it works benchmark      time:   [1.7764 us 1.8185 us 1.8755 us]                               
                        change: [-12.192% -7.0625% -2.2601%] (p = 0.01 < 0.05)
                        Performance has improved.
Found 21 outliers among 100 measurements (21.00%)
  2 (2.00%) high mild
  19 (19.00%) high severe

validator no fails benchmark                                                                             
                        time:   [5.7876 us 6.0999 us 6.4780 us]
                        change: [-6.4374% +0.9756% +9.2598%] (p = 0.81 > 0.05)
                        No change in performance detected.
Found 18 outliers among 100 measurements (18.00%)
  2 (2.00%) high mild
  16 (16.00%) high severe

validate benchmark      time:   [5.5771 us 5.7179 us 5.8830 us]                                
                        change: [-6.8120% -2.5218% +1.4732%] (p = 0.26 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe

```