### PR TITLE
Match lane index error message expected by SIMD spec tests

### DIFF
--- a/src/binary_reader.rs
+++ b/src/binary_reader.rs
@@ -1356,7 +1356,7 @@ impl<'a> BinaryReader<'a> {
         let index = self.read_u8()?;
         if index >= max {
             return Err(BinaryReaderError {
-                message: "lane index out of range",
+                message: "invalid lane index",
                 offset: self.original_position() - 1,
             });
         }


### PR DESCRIPTION
See https://github.com/WebAssembly/testsuite/blob/c70c3c8b136e5e7193135d40ec3960f4ef1cb20a/proposals/simd/simd_lane.wast#L398, e.g.