### PR TITLE
Ensure we have correct error messages for `(assert_invalid ...)` spec tests

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -35,7 +35,7 @@ where
 {
     loop {
         match *d.read() {
-            ParserState::Error(e) => panic!("unexpected error {:?}", e),
+            ParserState::Error(ref e) => panic!("unexpected error {}", e),
             ParserState::EndWasm => return,
             _ => (),
         }

--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -43,7 +43,7 @@ fn main() {
                 );
             }
             ParserState::EndWasm => break,
-            ParserState::Error(err) => panic!("Error: {:?}", err),
+            ParserState::Error(ref err) => panic!("Error: {:?}", err),
             _ => println!("{:?}", state),
         }
     }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -33,7 +33,7 @@ fn main() {
                 println!("  Import {}::{}", module, field)
             }
             ParserState::EndWasm => break,
-            ParserState::Error(err) => panic!("Error: {:?}", err),
+            ParserState::Error(ref err) => panic!("Error: {:?}", err),
             _ => ( /* println!(" Other {:?}", state); */ ),
         }
     }

--- a/src/binary_reader.rs
+++ b/src/binary_reader.rs
@@ -127,10 +127,10 @@ impl<'a> BinaryReader<'a> {
         if self.position < self.buffer.len() {
             Ok(())
         } else {
-            Err(BinaryReaderError {
-                message: "Unexpected EOF",
-                offset: self.original_position(),
-            })
+            Err(BinaryReaderError::new(
+                "Unexpected EOF",
+                self.original_position(),
+            ))
         }
     }
 
@@ -138,20 +138,20 @@ impl<'a> BinaryReader<'a> {
         if self.position + len <= self.buffer.len() {
             Ok(())
         } else {
-            Err(BinaryReaderError {
-                message: "Unexpected EOF",
-                offset: self.original_position(),
-            })
+            Err(BinaryReaderError::new(
+                "Unexpected EOF",
+                self.original_position(),
+            ))
         }
     }
 
     fn read_var_u1(&mut self) -> Result<u32> {
         let b = self.read_u8()?;
         if (b & 0xFE) != 0 {
-            return Err(BinaryReaderError {
-                message: "Invalid var_u1",
-                offset: self.original_position() - 1,
-            });
+            return Err(BinaryReaderError::new(
+                "Invalid var_u1",
+                self.original_position() - 1,
+            ));
         }
         Ok(b)
     }
@@ -159,10 +159,10 @@ impl<'a> BinaryReader<'a> {
     fn read_var_i7(&mut self) -> Result<i32> {
         let b = self.read_u8()?;
         if (b & 0x80) != 0 {
-            return Err(BinaryReaderError {
-                message: "Invalid var_i7",
-                offset: self.original_position() - 1,
-            });
+            return Err(BinaryReaderError::new(
+                "Invalid var_i7",
+                self.original_position() - 1,
+            ));
         }
         Ok((b << 25) as i32 >> 25)
     }
@@ -170,10 +170,10 @@ impl<'a> BinaryReader<'a> {
     pub(crate) fn read_var_u7(&mut self) -> Result<u32> {
         let b = self.read_u8()?;
         if (b & 0x80) != 0 {
-            return Err(BinaryReaderError {
-                message: "Invalid var_u7",
-                offset: self.original_position() - 1,
-            });
+            return Err(BinaryReaderError::new(
+                "Invalid var_u7",
+                self.original_position() - 1,
+            ));
         }
         Ok(b)
     }
@@ -191,10 +191,10 @@ impl<'a> BinaryReader<'a> {
             -0x12 => Ok(Type::NullRef),
             -0x20 => Ok(Type::Func),
             -0x40 => Ok(Type::EmptyBlockType),
-            _ => Err(BinaryReaderError {
-                message: "Invalid type",
-                offset: self.original_position() - 1,
-            }),
+            _ => Err(BinaryReaderError::new(
+                "Invalid type",
+                self.original_position() - 1,
+            )),
         }
     }
 
@@ -202,10 +202,10 @@ impl<'a> BinaryReader<'a> {
     pub fn read_local_count(&mut self) -> Result<usize> {
         let local_count = self.read_var_u32()? as usize;
         if local_count > MAX_WASM_FUNCTION_LOCALS {
-            return Err(BinaryReaderError {
-                message: "local_count is out of bounds",
-                offset: self.original_position() - 1,
-            });
+            return Err(BinaryReaderError::new(
+                "local_count is out of bounds",
+                self.original_position() - 1,
+            ));
         }
         Ok(local_count)
     }
@@ -214,18 +214,17 @@ impl<'a> BinaryReader<'a> {
     pub fn read_local_decl(&mut self, locals_total: &mut usize) -> Result<(u32, Type)> {
         let count = self.read_var_u32()?;
         let value_type = self.read_type()?;
-        *locals_total =
-            locals_total
-                .checked_add(count as usize)
-                .ok_or_else(|| BinaryReaderError {
-                    message: "locals_total is out of bounds",
-                    offset: self.original_position() - 1,
-                })?;
+        *locals_total = locals_total.checked_add(count as usize).ok_or_else(|| {
+            BinaryReaderError::new(
+                "locals_total is out of bounds",
+                self.original_position() - 1,
+            )
+        })?;
         if *locals_total > MAX_WASM_FUNCTION_LOCALS {
-            return Err(BinaryReaderError {
-                message: "locals_total is out of bounds",
-                offset: self.original_position() - 1,
-            });
+            return Err(BinaryReaderError::new(
+                "locals_total is out of bounds",
+                self.original_position() - 1,
+            ));
         }
         Ok((count, value_type))
     }
@@ -237,10 +236,10 @@ impl<'a> BinaryReader<'a> {
             1 => Ok(ExternalKind::Table),
             2 => Ok(ExternalKind::Memory),
             3 => Ok(ExternalKind::Global),
-            _ => Err(BinaryReaderError {
-                message: "Invalid external kind",
-                offset: self.original_position() - 1,
-            }),
+            _ => Err(BinaryReaderError::new(
+                "Invalid external kind",
+                self.original_position() - 1,
+            )),
         }
     }
 
@@ -248,10 +247,10 @@ impl<'a> BinaryReader<'a> {
         let form = self.read_type()?;
         let params_len = self.read_var_u32()? as usize;
         if params_len > MAX_WASM_FUNCTION_PARAMS {
-            return Err(BinaryReaderError {
-                message: "function params size is out of bound",
-                offset: self.original_position() - 1,
-            });
+            return Err(BinaryReaderError::new(
+                "function params size is out of bound",
+                self.original_position() - 1,
+            ));
         }
         let mut params: Vec<Type> = Vec::with_capacity(params_len);
         for _ in 0..params_len {
@@ -259,10 +258,10 @@ impl<'a> BinaryReader<'a> {
         }
         let returns_len = self.read_var_u32()? as usize;
         if returns_len > MAX_WASM_FUNCTION_RETURNS {
-            return Err(BinaryReaderError {
-                message: "function returns size is out of bound",
-                offset: self.original_position() - 1,
-            });
+            return Err(BinaryReaderError::new(
+                "function returns size is out of bound",
+                self.original_position() - 1,
+            ));
         }
         let mut returns: Vec<Type> = Vec::with_capacity(returns_len);
         for _ in 0..returns_len {
@@ -289,10 +288,10 @@ impl<'a> BinaryReader<'a> {
         let element_type = self.read_type()?;
         let flags = self.read_var_u32()?;
         if (flags & !0x1) != 0 {
-            return Err(BinaryReaderError {
-                message: "invalid table resizable limits flags",
-                offset: self.original_position() - 1,
-            });
+            return Err(BinaryReaderError::new(
+                "invalid table resizable limits flags",
+                self.original_position() - 1,
+            ));
         }
         let limits = self.read_resizable_limits((flags & 0x1) != 0)?;
         Ok(TableType {
@@ -304,10 +303,10 @@ impl<'a> BinaryReader<'a> {
     pub(crate) fn read_memory_type(&mut self) -> Result<MemoryType> {
         let flags = self.read_var_u32()?;
         if (flags & !0x3) != 0 {
-            return Err(BinaryReaderError {
-                message: "invalid table resizable limits flags",
-                offset: self.original_position() - 1,
-            });
+            return Err(BinaryReaderError::new(
+                "invalid table resizable limits flags",
+                self.original_position() - 1,
+            ));
         }
         let limits = self.read_resizable_limits((flags & 0x1) != 0)?;
         let shared = (flags & 0x2) != 0;
@@ -359,20 +358,17 @@ impl<'a> BinaryReader<'a> {
             10 => Ok(SectionCode::Code),
             11 => Ok(SectionCode::Data),
             12 => Ok(SectionCode::DataCount),
-            _ => Err(BinaryReaderError {
-                message: "Invalid section code",
-                offset,
-            }),
+            _ => Err(BinaryReaderError::new("Invalid section code", offset)),
         }
     }
 
     fn read_br_table(&mut self) -> Result<BrTable<'a>> {
         let targets_len = self.read_var_u32()? as usize;
         if targets_len > MAX_WASM_BR_TABLE_SIZE {
-            return Err(BinaryReaderError {
-                message: "br_table size is out of bound",
-                offset: self.original_position() - 1,
-            });
+            return Err(BinaryReaderError::new(
+                "br_table size is out of bound",
+                self.original_position() - 1,
+            ));
         }
         let start = self.position;
         for _ in 0..targets_len {
@@ -465,10 +461,10 @@ impl<'a> BinaryReader<'a> {
 
         let result = (self.read_u8()? << 7) | (byte & 0x7F);
         if result >= 0x100 {
-            return Err(BinaryReaderError {
-                message: "Invalid var_u8",
-                offset: self.original_position() - 1,
-            });
+            return Err(BinaryReaderError::new(
+                "Invalid var_u8",
+                self.original_position() - 1,
+            ));
         }
         Ok(result)
     }
@@ -492,10 +488,10 @@ impl<'a> BinaryReader<'a> {
             result |= ((byte & 0x7F) as u32) << shift;
             if shift >= 25 && (byte >> (32 - shift)) != 0 {
                 // The continuation bit or unused bits are set.
-                return Err(BinaryReaderError {
-                    message: "Invalid var_u32",
-                    offset: self.original_position() - 1,
-                });
+                return Err(BinaryReaderError::new(
+                    "Invalid var_u32",
+                    self.original_position() - 1,
+                ));
             }
             shift += 7;
             if (byte & 0x80) == 0 {
@@ -517,10 +513,10 @@ impl<'a> BinaryReader<'a> {
                 return Ok(());
             }
         }
-        Err(BinaryReaderError {
-            message: "Invalid var_32",
-            offset: self.original_position() - 1,
-        })
+        Err(BinaryReaderError::new(
+            "Invalid var_32",
+            self.original_position() - 1,
+        ))
     }
 
     /// Alias method for `BinaryReader::skip_var_u32`.
@@ -546,10 +542,10 @@ impl<'a> BinaryReader<'a> {
     pub fn skip_string(&mut self) -> Result<()> {
         let len = self.read_var_u32()? as usize;
         if len > MAX_WASM_STRING_SIZE {
-            return Err(BinaryReaderError {
-                message: "string size in out of bounds",
-                offset: self.original_position() - 1,
-            });
+            return Err(BinaryReaderError::new(
+                "string size in out of bounds",
+                self.original_position() - 1,
+            ));
         }
         self.skip_bytes(len)
     }
@@ -583,10 +579,10 @@ impl<'a> BinaryReader<'a> {
                 let continuation_bit = (byte & 0x80) != 0;
                 let sign_and_unused_bit = (byte << 1) as i8 >> (32 - shift);
                 if continuation_bit || (sign_and_unused_bit != 0 && sign_and_unused_bit != -1) {
-                    return Err(BinaryReaderError {
-                        message: "Invalid var_i32",
-                        offset: self.original_position() - 1,
-                    });
+                    return Err(BinaryReaderError::new(
+                        "Invalid var_i32",
+                        self.original_position() - 1,
+                    ));
                 }
                 return Ok(result);
             }
@@ -620,10 +616,10 @@ impl<'a> BinaryReader<'a> {
                 let continuation_bit = (byte & 0x80) != 0;
                 let sign_and_unused_bit = (byte << 1) as i8 >> (33 - shift);
                 if continuation_bit || (sign_and_unused_bit != 0 && sign_and_unused_bit != -1) {
-                    return Err(BinaryReaderError {
-                        message: "Invalid var_s33",
-                        offset: self.original_position() - 1,
-                    });
+                    return Err(BinaryReaderError::new(
+                        "Invalid var_s33",
+                        self.original_position() - 1,
+                    ));
                 }
                 return Ok(result);
             }
@@ -651,10 +647,10 @@ impl<'a> BinaryReader<'a> {
                 let continuation_bit = (byte & 0x80) != 0;
                 let sign_and_unused_bit = ((byte << 1) as i8) >> (64 - shift);
                 if continuation_bit || (sign_and_unused_bit != 0 && sign_and_unused_bit != -1) {
-                    return Err(BinaryReaderError {
-                        message: "Invalid var_i64",
-                        offset: self.original_position() - 1,
-                    });
+                    return Err(BinaryReaderError::new(
+                        "Invalid var_i64",
+                        self.original_position() - 1,
+                    ));
                 }
                 return Ok(result);
             }
@@ -695,25 +691,24 @@ impl<'a> BinaryReader<'a> {
     pub fn read_string(&mut self) -> Result<&'a str> {
         let len = self.read_var_u32()? as usize;
         if len > MAX_WASM_STRING_SIZE {
-            return Err(BinaryReaderError {
-                message: "string size in out of bounds",
-                offset: self.original_position() - 1,
-            });
+            return Err(BinaryReaderError::new(
+                "string size in out of bounds",
+                self.original_position() - 1,
+            ));
         }
         let bytes = self.read_bytes(len)?;
-        str::from_utf8(bytes).map_err(|_| BinaryReaderError {
-            message: "non-utf8 string",
-            offset: self.original_position() - 1,
+        str::from_utf8(bytes).map_err(|_| {
+            BinaryReaderError::new("invalid UTF-8 encoding", self.original_position() - 1)
         })
     }
 
     fn read_memarg_of_align(&mut self, max_align: u32) -> Result<MemoryImmediate> {
         let imm = self.read_memarg()?;
         if imm.flags > max_align {
-            return Err(BinaryReaderError {
-                message: "Unexpected memarg alignment",
-                offset: self.original_position() - 1,
-            });
+            return Err(BinaryReaderError::new(
+                "Unexpected memarg alignment",
+                self.original_position() - 1,
+            ));
         }
         Ok(imm)
     }
@@ -924,10 +919,10 @@ impl<'a> BinaryReader<'a> {
             },
 
             _ => {
-                return Err(BinaryReaderError {
-                    message: "Unknown 0xFE opcode",
-                    offset: self.original_position() - 1,
-                });
+                return Err(BinaryReaderError::new(
+                    "Unknown 0xFE opcode",
+                    self.original_position() - 1,
+                ));
             }
         })
     }
@@ -940,10 +935,7 @@ impl<'a> BinaryReader<'a> {
             self.position = position;
             let idx = self.read_var_s33()?;
             if idx < 0 || idx > (std::u32::MAX as i64) {
-                return Err(BinaryReaderError {
-                    message: "invalid function type",
-                    offset: position,
-                });
+                return Err(BinaryReaderError::new("invalid function type", position));
             }
             Ok(TypeOrFuncType::FuncType(idx as u32))
         }
@@ -991,10 +983,10 @@ impl<'a> BinaryReader<'a> {
             0x1c => {
                 let results = self.read_var_u32()?;
                 if results != 1 {
-                    return Err(BinaryReaderError {
-                        message: "bad number of results",
-                        offset: self.position,
-                    });
+                    return Err(BinaryReaderError::new(
+                        "bad number of results",
+                        self.position,
+                    ));
                 }
                 Operator::TypedSelect {
                     ty: self.read_type()?,
@@ -1249,10 +1241,10 @@ impl<'a> BinaryReader<'a> {
             0xfe => self.read_0xfe_operator()?,
 
             _ => {
-                return Err(BinaryReaderError {
-                    message: "Unknown opcode",
-                    offset: self.original_position() - 1,
-                });
+                return Err(BinaryReaderError::new(
+                    "Unknown opcode",
+                    self.original_position() - 1,
+                ));
             }
         })
     }
@@ -1273,10 +1265,10 @@ impl<'a> BinaryReader<'a> {
                 let segment = self.read_var_u32()?;
                 let mem = self.read_u8()?;
                 if mem != 0 {
-                    return Err(BinaryReaderError {
-                        message: "reserved byte must be zero",
-                        offset: self.original_position() - 1,
-                    });
+                    return Err(BinaryReaderError::new(
+                        "reserved byte must be zero",
+                        self.original_position() - 1,
+                    ));
                 }
                 Operator::MemoryInit { segment }
             }
@@ -1287,27 +1279,27 @@ impl<'a> BinaryReader<'a> {
             0x0a => {
                 let dst = self.read_u8()?;
                 if dst != 0 {
-                    return Err(BinaryReaderError {
-                        message: "reserved byte must be zero",
-                        offset: self.original_position() - 1,
-                    });
+                    return Err(BinaryReaderError::new(
+                        "reserved byte must be zero",
+                        self.original_position() - 1,
+                    ));
                 }
                 let src = self.read_u8()?;
                 if src != 0 {
-                    return Err(BinaryReaderError {
-                        message: "reserved byte must be zero",
-                        offset: self.original_position() - 1,
-                    });
+                    return Err(BinaryReaderError::new(
+                        "reserved byte must be zero",
+                        self.original_position() - 1,
+                    ));
                 }
                 Operator::MemoryCopy
             }
             0x0b => {
                 let mem = self.read_u8()?;
                 if mem != 0 {
-                    return Err(BinaryReaderError {
-                        message: "reserved byte must be zero",
-                        offset: self.original_position() - 1,
-                    });
+                    return Err(BinaryReaderError::new(
+                        "reserved byte must be zero",
+                        self.original_position() - 1,
+                    ));
                 }
                 Operator::MemoryFill
             }
@@ -1344,10 +1336,10 @@ impl<'a> BinaryReader<'a> {
             }
 
             _ => {
-                return Err(BinaryReaderError {
-                    message: "Unknown 0xfc opcode",
-                    offset: self.original_position() - 1,
-                });
+                return Err(BinaryReaderError::new(
+                    "Unknown 0xfc opcode",
+                    self.original_position() - 1,
+                ));
             }
         })
     }
@@ -1355,10 +1347,10 @@ impl<'a> BinaryReader<'a> {
     fn read_lane_index(&mut self, max: u32) -> Result<SIMDLaneIndex> {
         let index = self.read_u8()?;
         if index >= max {
-            return Err(BinaryReaderError {
-                message: "invalid lane index",
-                offset: self.original_position() - 1,
-            });
+            return Err(BinaryReaderError::new(
+                "invalid lane index",
+                self.original_position() - 1,
+            ));
         }
         Ok(index as SIMDLaneIndex)
     }
@@ -1612,10 +1604,10 @@ impl<'a> BinaryReader<'a> {
             0xd9 => Operator::I8x16RoundingAverageU,
             0xda => Operator::I16x8RoundingAverageU,
             _ => {
-                return Err(BinaryReaderError {
-                    message: "Unknown 0xfd opcode",
-                    offset: self.original_position() - 1,
-                });
+                return Err(BinaryReaderError::new(
+                    "Unknown 0xfd opcode",
+                    self.original_position() - 1,
+                ));
             }
         })
     }
@@ -1623,17 +1615,17 @@ impl<'a> BinaryReader<'a> {
     pub(crate) fn read_file_header(&mut self) -> Result<u32> {
         let magic_number = self.read_bytes(4)?;
         if magic_number != WASM_MAGIC_NUMBER {
-            return Err(BinaryReaderError {
-                message: "Bad magic number",
-                offset: self.original_position() - 4,
-            });
+            return Err(BinaryReaderError::new(
+                "Bad magic number",
+                self.original_position() - 4,
+            ));
         }
         let version = self.read_u32()?;
         if version != WASM_SUPPORTED_VERSION && version != WASM_EXPERIMENTAL_VERSION {
-            return Err(BinaryReaderError {
-                message: "Bad version number",
-                offset: self.original_position() - 4,
-            });
+            return Err(BinaryReaderError::new(
+                "Bad version number",
+                self.original_position() - 4,
+            ));
         }
         Ok(version)
     }
@@ -1657,10 +1649,10 @@ impl<'a> BinaryReader<'a> {
             0 => Ok(NameType::Module),
             1 => Ok(NameType::Function),
             2 => Ok(NameType::Local),
-            _ => Err(BinaryReaderError {
-                message: "Invalid name type",
-                offset: self.original_position() - 1,
-            }),
+            _ => Err(BinaryReaderError::new(
+                "Invalid name type",
+                self.original_position() - 1,
+            )),
         }
     }
 
@@ -1669,10 +1661,10 @@ impl<'a> BinaryReader<'a> {
         Ok(match ty {
             1 => LinkingType::StackPointer(self.read_var_u32()?),
             _ => {
-                return Err(BinaryReaderError {
-                    message: "Invalid linking type",
-                    offset: self.original_position() - 1,
-                });
+                return Err(BinaryReaderError::new(
+                    "Invalid linking type",
+                    self.original_position() - 1,
+                ));
             }
         })
     }
@@ -1688,10 +1680,10 @@ impl<'a> BinaryReader<'a> {
             5 => Ok(RelocType::GlobalAddrI32),
             6 => Ok(RelocType::TypeIndexLEB),
             7 => Ok(RelocType::GlobalIndexLEB),
-            _ => Err(BinaryReaderError {
-                message: "Invalid reloc type",
-                offset: self.original_position() - 1,
-            }),
+            _ => Err(BinaryReaderError::new(
+                "Invalid reloc type",
+                self.original_position() - 1,
+            )),
         }
     }
 
@@ -1738,9 +1730,11 @@ impl<'a> BrTable<'a> {
         while !reader.eof() {
             table.push(reader.read_var_u32()?);
         }
-        let default_target = table.pop().ok_or_else(|| BinaryReaderError {
-            message: "br_table missing default target",
-            offset: reader.original_position(),
+        let default_target = table.pop().ok_or_else(|| {
+            BinaryReaderError::new(
+                "br_table missing default target",
+                reader.original_position(),
+            )
         })?;
         Ok((table.into_boxed_slice(), default_target))
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -456,10 +456,10 @@ impl<'a> Parser<'a> {
             .get_items_reader()?;
         let num_elements = reader.get_count() as usize;
         if num_elements > MAX_WASM_TABLE_ENTRIES {
-            return Err(BinaryReaderError {
-                message: "num_elements is out of bounds",
-                offset: 0, // reader.position - 1, // TODO offset
-            });
+            return Err(BinaryReaderError::new(
+                "num_elements is out of bounds",
+                0, // reader.position - 1, // TODO offset
+            ));
         }
         let mut elements = Vec::with_capacity(num_elements);
         for _ in 0..num_elements {
@@ -487,27 +487,26 @@ impl<'a> Parser<'a> {
         let mut reader = function_body.get_locals_reader()?;
         let local_count = reader.get_count() as usize;
         if local_count > MAX_WASM_FUNCTION_LOCALS {
-            return Err(BinaryReaderError {
-                message: "local_count is out of bounds",
-                offset: reader.original_position() - 1,
-            });
+            return Err(BinaryReaderError::new(
+                "local_count is out of bounds",
+                reader.original_position() - 1,
+            ));
         }
         let mut locals: Vec<(u32, Type)> = Vec::with_capacity(local_count);
         let mut locals_total: usize = 0;
         for _ in 0..local_count {
             let (count, ty) = reader.read()?;
-            locals_total =
-                locals_total
-                    .checked_add(count as usize)
-                    .ok_or_else(|| BinaryReaderError {
-                        message: "locals_total is out of bounds",
-                        offset: reader.original_position() - 1,
-                    })?;
+            locals_total = locals_total.checked_add(count as usize).ok_or_else(|| {
+                BinaryReaderError::new(
+                    "locals_total is out of bounds",
+                    reader.original_position() - 1,
+                )
+            })?;
             if locals_total > MAX_WASM_FUNCTION_LOCALS {
-                return Err(BinaryReaderError {
-                    message: "locals_total is out of bounds",
-                    offset: reader.original_position() - 1,
-                });
+                return Err(BinaryReaderError::new(
+                    "locals_total is out of bounds",
+                    reader.original_position() - 1,
+                ));
             }
             locals.push((count, ty));
         }
@@ -532,10 +531,10 @@ impl<'a> Parser<'a> {
                 return Ok(());
             }
             let reader = self.operators_reader.as_ref().expect("operator reader");
-            return Err(BinaryReaderError {
-                message: "Expected end of function marker",
-                offset: reader.original_position(),
-            });
+            return Err(BinaryReaderError::new(
+                "Expected end of function marker",
+                reader.original_position(),
+            ));
         }
         let reader = self.operators_reader.as_mut().expect("operator reader");
         let op = reader.read()?;
@@ -590,10 +589,10 @@ impl<'a> Parser<'a> {
     {
         let count = naming_reader.get_count() as usize;
         if count > limit {
-            return Err(BinaryReaderError {
-                message: "name map size is out of bound",
-                offset: naming_reader.original_position() - 1,
-            });
+            return Err(BinaryReaderError::new(
+                "name map size is out of bound",
+                naming_reader.original_position() - 1,
+            ));
         }
         let mut result = Vec::with_capacity(count);
         for _ in 0..count {
@@ -615,10 +614,10 @@ impl<'a> Parser<'a> {
                 let mut reader = locals.get_function_local_reader()?;
                 let funcs_len = reader.get_count() as usize;
                 if funcs_len > MAX_WASM_FUNCTIONS {
-                    return Err(BinaryReaderError {
-                        message: "function count is out of bounds",
-                        offset: reader.original_position() - 1,
-                    });
+                    return Err(BinaryReaderError::new(
+                        "function count is out of bounds",
+                        reader.original_position() - 1,
+                    ));
                 }
                 let mut funcs: Vec<LocalName<'a>> = Vec::with_capacity(funcs_len);
                 for _ in 0..funcs_len {

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -17,10 +17,18 @@ use std::error::Error;
 use std::fmt;
 use std::result;
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct BinaryReaderError {
-    pub message: &'static str,
-    pub offset: usize,
+    // Wrap the actual error data in a `Box` so that the error is just one
+    // word. This means that we can continue returning small `Result`s in
+    // registers.
+    pub(crate) inner: Box<BinaryReaderErrorInner>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct BinaryReaderErrorInner {
+    pub(crate) message: String,
+    pub(crate) offset: usize,
 }
 
 pub type Result<T> = result::Result<T, BinaryReaderError>;
@@ -29,7 +37,30 @@ impl Error for BinaryReaderError {}
 
 impl fmt::Display for BinaryReaderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} (at offset {})", self.message, self.offset)
+        write!(
+            f,
+            "{} (at offset {})",
+            self.inner.message, self.inner.offset
+        )
+    }
+}
+
+impl BinaryReaderError {
+    pub(crate) fn new(message: impl Into<String>, offset: usize) -> Self {
+        let message = message.into();
+        BinaryReaderError {
+            inner: Box::new(BinaryReaderErrorInner { message, offset }),
+        }
+    }
+
+    /// Get this error's message.
+    pub fn message(&self) -> &str {
+        &self.inner.message
+    }
+
+    /// Get the offset within the Wasm binary where the error occured.
+    pub fn offset(&self) -> usize {
+        self.inner.offset
     }
 }
 

--- a/src/readers/code_section.rs
+++ b/src/readers/code_section.rs
@@ -151,10 +151,10 @@ impl<'a> CodeSectionReader<'a> {
 
     fn verify_body_end(&self, end: usize) -> Result<()> {
         if self.reader.buffer.len() < end {
-            return Err(BinaryReaderError {
-                message: "Function body extends past end of the code section",
-                offset: self.reader.original_offset + self.reader.buffer.len(),
-            });
+            return Err(BinaryReaderError::new(
+                "Function body extends past end of the code section",
+                self.reader.original_offset + self.reader.buffer.len(),
+            ));
         }
         Ok(())
     }

--- a/src/readers/data_count_section.rs
+++ b/src/readers/data_count_section.rs
@@ -19,10 +19,10 @@ pub(crate) fn read_data_count_section_content(data: &[u8], offset: usize) -> Res
     let mut reader = BinaryReader::new_with_offset(data, offset);
     let count = reader.read_var_u32()?;
     if !reader.eof() {
-        return Err(BinaryReaderError {
-            message: "Unexpected content in the data count section",
-            offset: offset + reader.position,
-        });
+        return Err(BinaryReaderError::new(
+            "Unexpected content in the data count section",
+            offset + reader.position,
+        ));
     }
     Ok(count)
 }

--- a/src/readers/data_section.rs
+++ b/src/readers/data_section.rs
@@ -55,10 +55,10 @@ impl<'a> DataSectionReader<'a> {
 
     fn verify_data_end(&self, end: usize) -> Result<()> {
         if self.reader.buffer.len() < end {
-            return Err(BinaryReaderError {
-                message: "Data segment extends past end of the data section",
-                offset: self.reader.original_offset + self.reader.buffer.len(),
-            });
+            return Err(BinaryReaderError::new(
+                "Data segment extends past end of the data section",
+                self.reader.original_offset + self.reader.buffer.len(),
+            ));
         }
         Ok(())
     }
@@ -102,10 +102,10 @@ impl<'a> DataSectionReader<'a> {
                 0 => 0,
                 2 => self.reader.read_var_u32()?,
                 _ => {
-                    return Err(BinaryReaderError {
-                        message: "invalid flags byte in data segment",
-                        offset: self.reader.original_position() - 1,
-                    });
+                    return Err(BinaryReaderError::new(
+                        "invalid flags byte in data segment",
+                        self.reader.original_position() - 1,
+                    ));
                 }
             };
             let init_expr = {

--- a/src/readers/element_section.rs
+++ b/src/readers/element_section.rs
@@ -93,21 +93,11 @@ impl<'a> ElementItemsReader<'a> {
             let ret = match self.reader.read_operator()? {
                 Operator::RefNull => ElementItem::Null,
                 Operator::RefFunc { function_index } => ElementItem::Func(function_index),
-                _ => {
-                    return Err(BinaryReaderError {
-                        message: "invalid passive segment",
-                        offset,
-                    })
-                }
+                _ => return Err(BinaryReaderError::new("invalid passive segment", offset)),
             };
             match self.reader.read_operator()? {
                 Operator::End => {}
-                _ => {
-                    return Err(BinaryReaderError {
-                        message: "invalid passive segment",
-                        offset,
-                    })
-                }
+                _ => return Err(BinaryReaderError::new("invalid passive segment", offset)),
             }
             Ok(ret)
         } else {
@@ -205,10 +195,10 @@ impl<'a> ElementSectionReader<'a> {
     {
         let flags = self.reader.read_var_u32()?;
         if (flags & !0b111) != 0 {
-            return Err(BinaryReaderError {
-                message: "invalid flags byte in element segment",
-                offset: self.reader.original_position() - 1,
-            });
+            return Err(BinaryReaderError::new(
+                "invalid flags byte in element segment",
+                self.reader.original_position() - 1,
+            ));
         }
         let kind = if flags & 0b001 != 0 {
             if flags & 0b010 != 0 {
@@ -241,10 +231,10 @@ impl<'a> ElementSectionReader<'a> {
                 match self.reader.read_external_kind()? {
                     ExternalKind::Function => Type::AnyFunc,
                     _ => {
-                        return Err(BinaryReaderError {
-                            message: "only the function external type is supported in elem segment",
-                            offset: self.reader.original_position() - 1,
-                        });
+                        return Err(BinaryReaderError::new(
+                            "only the function external type is supported in elem segment",
+                            self.reader.original_position() - 1,
+                        ));
                     }
                 }
             }

--- a/src/readers/module.rs
+++ b/src/readers/module.rs
@@ -368,16 +368,16 @@ impl<'a> ModuleReader<'a> {
 
     fn verify_section_end(&self, end: usize) -> Result<()> {
         if self.reader.buffer.len() < end {
-            return Err(BinaryReaderError {
-                message: "Section body extends past end of file",
-                offset: self.reader.buffer.len(),
-            });
+            return Err(BinaryReaderError::new(
+                "Section body extends past end of file",
+                self.reader.buffer.len(),
+            ));
         }
         if self.reader.position > end {
-            return Err(BinaryReaderError {
-                message: "Section header is too big to fit into section body",
-                offset: end,
-            });
+            return Err(BinaryReaderError::new(
+                "Section header is too big to fit into section body",
+                end,
+            ));
         }
         Ok(())
     }

--- a/src/readers/name_section.rs
+++ b/src/readers/name_section.rs
@@ -174,10 +174,10 @@ impl<'a> NameSectionReader<'a> {
 
     fn verify_section_end(&self, end: usize) -> Result<()> {
         if self.reader.buffer.len() < end {
-            return Err(BinaryReaderError {
-                message: "Name entry extends past end of the code section",
-                offset: self.reader.original_offset + self.reader.buffer.len(),
-            });
+            return Err(BinaryReaderError::new(
+                "Name entry extends past end of the code section",
+                self.reader.original_offset + self.reader.buffer.len(),
+            ));
         }
         Ok(())
     }

--- a/src/readers/operators.rs
+++ b/src/readers/operators.rs
@@ -42,10 +42,10 @@ impl<'a> OperatorsReader<'a> {
         if self.eof() {
             return Ok(());
         }
-        Err(BinaryReaderError {
-            message: "Unexpected data at the end of operators",
-            offset: self.reader.original_position(),
-        })
+        Err(BinaryReaderError::new(
+            "Unexpected data at the end of operators",
+            self.reader.original_position(),
+        ))
     }
 
     pub fn read<'b>(&mut self) -> Result<Operator<'b>>

--- a/src/readers/section_reader.rs
+++ b/src/readers/section_reader.rs
@@ -24,10 +24,10 @@ pub trait SectionReader {
         if self.eof() {
             return Ok(());
         }
-        Err(BinaryReaderError {
-            message: "Unexpected data at the end of the section",
-            offset: self.original_position(),
-        })
+        Err(BinaryReaderError::new(
+            "Unexpected data at the end of the section",
+            self.original_position(),
+        ))
     }
 }
 

--- a/src/readers/sourcemappingurl_section.rs
+++ b/src/readers/sourcemappingurl_section.rs
@@ -22,10 +22,10 @@ pub(crate) fn read_sourcemappingurl_section_content<'a>(
     let mut reader = BinaryReader::new_with_offset(data, offset);
     let url = reader.read_string()?;
     if !reader.eof() {
-        return Err(BinaryReaderError {
-            message: "Unexpected content in the sourceMappingURL section",
-            offset: offset + reader.position,
-        });
+        return Err(BinaryReaderError::new(
+            "Unexpected content in the sourceMappingURL section",
+            offset + reader.position,
+        ));
     }
     Ok(url)
 }

--- a/src/readers/start_section.rs
+++ b/src/readers/start_section.rs
@@ -19,10 +19,10 @@ pub(crate) fn read_start_section_content(data: &[u8], offset: usize) -> Result<u
     let mut reader = BinaryReader::new_with_offset(data, offset);
     let start_index = reader.read_var_u32()?;
     if !reader.eof() {
-        return Err(BinaryReaderError {
-            message: "Unexpected content in the start section",
-            offset: offset + reader.position,
-        });
+        return Err(BinaryReaderError::new(
+            "Unexpected content in the start section",
+            offset + reader.position,
+        ));
     }
     Ok(start_index)
 }

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -31,7 +31,7 @@ use crate::primitives::{
 
 use crate::operators_validator::{
     is_subtype_supertype, FunctionEnd, OperatorValidator, OperatorValidatorConfig,
-    DEFAULT_OPERATOR_VALIDATOR_CONFIG,
+    OperatorValidatorError, DEFAULT_OPERATOR_VALIDATOR_CONFIG,
 };
 use crate::parser::{Parser, ParserInput, ParserState, WasmDecoder};
 use crate::{ElemSectionEntryTable, ElementItem};
@@ -191,18 +191,23 @@ impl<'a> ValidatingParser<'a> {
         &self.resources
     }
 
-    fn set_validation_error(&mut self, message: &'static str) {
-        self.validation_error = Some(ParserState::Error(BinaryReaderError {
+    fn set_validation_error(&mut self, message: impl Into<String>) {
+        self.validation_error = Some(ParserState::Error(BinaryReaderError::new(
             message,
-            offset: self.read_position.unwrap(),
-        }))
+            self.read_position.unwrap(),
+        )))
     }
 
-    fn create_error<T>(&self, message: &'static str) -> ValidatorResult<'a, T> {
-        Err(ParserState::Error(BinaryReaderError {
+    fn set_operator_validation_error(&mut self, e: OperatorValidatorError) {
+        let offset = self.read_position.unwrap();
+        self.validation_error = Some(ParserState::Error(e.set_offset(offset)));
+    }
+
+    fn create_error<T>(&self, message: impl Into<String>) -> ValidatorResult<'a, T> {
+        Err(ParserState::Error(BinaryReaderError::new(
             message,
-            offset: self.read_position.unwrap(),
-        }))
+            self.read_position.unwrap(),
+        )))
     }
 
     fn check_value_type(&self, ty: Type) -> ValidatorResult<'a, ()> {
@@ -233,7 +238,7 @@ impl<'a> ValidatingParser<'a> {
 
     fn check_limits(&self, limits: &ResizableLimits) -> ValidatorResult<'a, ()> {
         if limits.maximum.is_some() && limits.initial > limits.maximum.unwrap() {
-            return self.create_error("maximum limits less than initial");
+            return self.create_error("size minimum must not be greater than maximum");
         }
         Ok(())
     }
@@ -243,7 +248,7 @@ impl<'a> ValidatingParser<'a> {
             self.check_value_types(&*func_type.params)?;
             self.check_value_types(&*func_type.returns)?;
             if !self.config.operator_config.enable_multi_value && func_type.returns.len() > 1 {
-                self.create_error("func type returns multiple values")
+                self.create_error("invalid result arity: func type returns multiple values")
             } else {
                 Ok(())
             }
@@ -268,11 +273,11 @@ impl<'a> ValidatingParser<'a> {
         self.check_limits(&memory_type.limits)?;
         let initial = memory_type.limits.initial;
         if initial as usize > MAX_WASM_MEMORY_PAGES {
-            return self.create_error("memory initial value exceeds limit");
+            return self.create_error("memory size must be at most 65536 pages (4GiB)");
         }
         let maximum = memory_type.limits.maximum;
         if maximum.is_some() && maximum.unwrap() as usize > MAX_WASM_MEMORY_PAGES {
-            return self.create_error("memory maximum value exceeds limit");
+            return self.create_error("memory size must be at most 65536 pages (4GiB)");
         }
         Ok(())
     }
@@ -288,7 +293,7 @@ impl<'a> ValidatingParser<'a> {
                     return self.create_error("functions count out of bounds");
                 }
                 if type_index as usize >= self.resources.types.len() {
-                    return self.create_error("type index out of bounds");
+                    return self.create_error("unknown type: type index out of bounds");
                 }
                 Ok(())
             }
@@ -296,13 +301,13 @@ impl<'a> ValidatingParser<'a> {
                 if !self.config.operator_config.enable_reference_types
                     && self.resources.tables.len() >= MAX_WASM_TABLES
                 {
-                    return self.create_error("tables count must be at most 1");
+                    return self.create_error("multiple tables: tables count must be at most 1");
                 }
                 self.check_table_type(table_type)
             }
             ImportSectionEntryType::Memory(ref memory_type) => {
                 if self.resources.memories.len() >= MAX_WASM_MEMORIES {
-                    return self.create_error("memory count must be at most 1");
+                    return self.create_error("multiple memories: memory count must be at most 1");
                 }
                 self.check_memory_type(memory_type)
             }
@@ -318,7 +323,9 @@ impl<'a> ValidatingParser<'a> {
     fn check_init_expression_operator(&self, operator: &Operator) -> ValidatorResult<'a, ()> {
         let state = self.init_expression_state.as_ref().unwrap();
         if state.validated {
-            return self.create_error("only one init_expr operator is expected");
+            return self.create_error(
+                "constant expression required: type mismatch: only one init_expr operator is expected",
+            );
         }
         let ty = match *operator {
             Operator::I32Const { .. } => Type::I32,
@@ -339,20 +346,27 @@ impl<'a> ValidatingParser<'a> {
             }
             Operator::GlobalGet { global_index } => {
                 if global_index as usize >= state.global_count {
-                    return self.create_error("init_expr global index out of bounds");
+                    return self
+                        .create_error("unknown global: init_expr global index out of bounds");
                 }
                 self.resources.globals[global_index as usize].content_type
             }
             Operator::RefFunc { function_index } => {
                 if function_index as usize >= state.function_count {
-                    return self.create_error("init_expr function index out of bounds");
+                    return self.create_error(format!(
+                        "unknown function {}: init_expr function index out of bounds",
+                        function_index
+                    ));
                 }
                 Type::AnyFunc
             }
-            _ => return self.create_error("invalid init_expr operator"),
+            _ => {
+                return self
+                    .create_error("constant expression required: invalid init_expr operator")
+            }
         };
         if !is_subtype_supertype(ty, state.ty) {
-            return self.create_error("invalid init_expr type");
+            return self.create_error("type mismatch: invalid init_expr type");
         }
         Ok(())
     }
@@ -364,27 +378,30 @@ impl<'a> ValidatingParser<'a> {
         index: u32,
     ) -> ValidatorResult<'a, ()> {
         if self.exported_names.contains(field) {
-            return self.create_error("non-unique export name");
+            return self.create_error("duplicate export name");
         }
         match kind {
             ExternalKind::Function => {
                 if index as usize >= self.resources.func_type_indices.len() {
-                    return self.create_error("exported function index out of bounds");
+                    return self
+                        .create_error("unknown function: exported function index out of bounds");
                 }
             }
             ExternalKind::Table => {
                 if index as usize >= self.resources.tables.len() {
-                    return self.create_error("exported table index out of bounds");
+                    return self.create_error("unknown table: exported table index out of bounds");
                 }
             }
             ExternalKind::Memory => {
                 if index as usize >= self.resources.memories.len() {
-                    return self.create_error("exported memory index out of bounds");
+                    return self
+                        .create_error("unknown memory: exported memory index out of bounds");
                 }
             }
             ExternalKind::Global => {
                 if index as usize >= self.resources.globals.len() {
-                    return self.create_error("exported global index out of bounds");
+                    return self
+                        .create_error("unknown global: exported global index out of bounds");
                 }
             }
         };
@@ -393,7 +410,7 @@ impl<'a> ValidatingParser<'a> {
 
     fn check_start(&self, func_index: u32) -> ValidatorResult<'a, ()> {
         if func_index as usize >= self.resources.func_type_indices.len() {
-            return self.create_error("start function index out of bounds");
+            return self.create_error("unknown function: start function index out of bounds");
         }
         let type_index = self.resources.func_type_indices[func_index as usize];
         let ty = &self.resources.types[type_index as usize];
@@ -472,7 +489,7 @@ impl<'a> ValidatingParser<'a> {
             }
             ParserState::FunctionSectionEntry(type_index) => {
                 if type_index as usize >= self.resources.types.len() {
-                    self.set_validation_error("func type index out of bounds");
+                    self.set_validation_error("unknown type: func type index out of bounds");
                 } else if self.resources.func_type_indices.len() >= MAX_WASM_FUNCTIONS {
                     self.set_validation_error("functions count out of bounds");
                 } else {
@@ -483,7 +500,7 @@ impl<'a> ValidatingParser<'a> {
                 if !self.config.operator_config.enable_reference_types
                     && self.resources.tables.len() >= MAX_WASM_TABLES
                 {
-                    self.set_validation_error("tables count must be at most 1");
+                    self.set_validation_error("multiple tables: tables count must be at most 1");
                 } else {
                     self.validation_error = self.check_table_type(table_type).err();
                     self.resources.tables.push(table_type.clone());
@@ -491,7 +508,9 @@ impl<'a> ValidatingParser<'a> {
             }
             ParserState::MemorySectionEntry(ref memory_type) => {
                 if self.resources.memories.len() >= MAX_WASM_MEMORIES {
-                    self.set_validation_error("memories count must be at most 1");
+                    self.set_validation_error(
+                        "multiple memories: memories count must be at most 1",
+                    );
                 } else {
                     self.validation_error = self.check_memory_type(memory_type).err();
                     self.resources.memories.push(memory_type.clone());
@@ -520,7 +539,7 @@ impl<'a> ValidatingParser<'a> {
             }
             ParserState::EndInitExpressionBody => {
                 if !self.init_expression_state.as_ref().unwrap().validated {
-                    self.set_validation_error("init_expr is empty");
+                    self.set_validation_error("type mismatch: init_expr is empty");
                 }
                 self.init_expression_state = None;
             }
@@ -540,7 +559,9 @@ impl<'a> ValidatingParser<'a> {
                     let table = match self.resources.tables.get(table_index as usize) {
                         Some(t) => t,
                         None => {
-                            self.set_validation_error("element section table index out of bounds");
+                            self.set_validation_error(
+                                "unknown table: element section table index out of bounds",
+                            );
                             return;
                         }
                     };
@@ -564,7 +585,9 @@ impl<'a> ValidatingParser<'a> {
                 for item in &**indices {
                     if let ElementItem::Func(func_index) = item {
                         if *func_index as usize >= self.resources.func_type_indices.len() {
-                            self.set_validation_error("element func index out of bounds");
+                            self.set_validation_error(
+                                "unknown function: element func index out of bounds",
+                            );
                             break;
                         }
                     }
@@ -592,7 +615,7 @@ impl<'a> ValidatingParser<'a> {
                     .process_operator(operator, &self.resources);
 
                 if let Err(err) = check {
-                    self.set_validation_error(err);
+                    self.set_operator_validation_error(err);
                 }
             }
             ParserState::EndFunctionBody => {
@@ -602,7 +625,7 @@ impl<'a> ValidatingParser<'a> {
                     .unwrap()
                     .process_end_function();
                 if let Err(err) = check {
-                    self.set_validation_error(err);
+                    self.set_operator_validation_error(err);
                 }
                 self.current_func_index += 1;
                 self.current_operator_validator = None;
@@ -612,7 +635,9 @@ impl<'a> ValidatingParser<'a> {
             }
             ParserState::BeginActiveDataSectionEntry(memory_index) => {
                 if memory_index as usize >= self.resources.memories.len() {
-                    self.set_validation_error("data section memory index out of bounds");
+                    self.set_validation_error(
+                        "unknown memory: data section memory index out of bounds",
+                    );
                 } else {
                     self.init_expression_state = Some(InitExpressionState {
                         ty: Type::I32,
@@ -798,18 +823,16 @@ impl<'b> ValidatingOperatorParser<'b> {
         let op = self.reader.read_operator()?;
         match self.operator_validator.process_operator(&op, resources) {
             Err(err) => {
-                return Err(BinaryReaderError {
-                    message: err,
-                    offset: self.func_body_offset + self.reader.current_position(),
-                });
+                let offset = self.func_body_offset + self.reader.current_position();
+                return Err(err.set_offset(offset));
             }
             Ok(FunctionEnd::Yes) => {
                 self.end_function = true;
                 if !self.reader.eof() {
-                    return Err(BinaryReaderError {
-                        message: "unexpected end of function",
-                        offset: self.func_body_offset + self.reader.current_position(),
-                    });
+                    return Err(BinaryReaderError::new(
+                        "unexpected end of function",
+                        self.func_body_offset + self.reader.current_position(),
+                    ));
                 }
             }
             _ => (),
@@ -842,27 +865,23 @@ pub fn validate_function_body<
     let mut locals_reader = function_body.get_locals_reader()?;
     let local_count = locals_reader.get_count() as usize;
     if local_count > MAX_WASM_FUNCTION_LOCALS {
-        return Err(BinaryReaderError {
-            message: "locals exceed maximum",
-            offset: locals_reader.original_position(),
-        });
+        return Err(BinaryReaderError::new(
+            "locals exceed maximum",
+            locals_reader.original_position(),
+        ));
     }
     let mut locals: Vec<(u32, Type)> = Vec::with_capacity(local_count);
     let mut locals_total: usize = 0;
     for _ in 0..local_count {
         let (count, ty) = locals_reader.read()?;
-        locals_total =
-            locals_total
-                .checked_add(count as usize)
-                .ok_or_else(|| BinaryReaderError {
-                    message: "locals overflow",
-                    offset: locals_reader.original_position(),
-                })?;
+        locals_total = locals_total.checked_add(count as usize).ok_or_else(|| {
+            BinaryReaderError::new("locals overflow", locals_reader.original_position())
+        })?;
         if locals_total > MAX_WASM_FUNCTION_LOCALS {
-            return Err(BinaryReaderError {
-                message: "locals exceed maximum",
-                offset: locals_reader.original_position(),
-            });
+            return Err(BinaryReaderError::new(
+                "locals exceed maximum",
+                locals_reader.original_position(),
+            ));
         }
         locals.push((count, ty));
     }
@@ -886,7 +905,7 @@ pub fn validate_function_body<
         let (ref op, offset) = item?;
         match operator_validator
             .process_operator(op, resources)
-            .map_err(|message| BinaryReaderError { message, offset })?
+            .map_err(|e| e.set_offset(offset))?
         {
             FunctionEnd::Yes => {
                 eof_found = true;
@@ -897,10 +916,7 @@ pub fn validate_function_body<
         }
     }
     if !eof_found {
-        return Err(BinaryReaderError {
-            message: "end of function not found",
-            offset: last_op,
-        });
+        return Err(BinaryReaderError::new("end of function not found", last_op));
     }
     Ok(())
 }
@@ -916,7 +932,7 @@ pub fn validate(bytes: &[u8], config: Option<ValidatingParserConfig>) -> Result<
         let state = parser.read_with_input(next_input);
         match *state {
             ParserState::EndWasm => break,
-            ParserState::Error(e) => return Err(e),
+            ParserState::Error(ref e) => return Err(e.clone()),
             ParserState::BeginFunctionBody { range } => {
                 parser_input = Some(ParserInput::SkipFunctionBody);
                 func_ranges.push(range);


### PR DESCRIPTION
Started on `assert_malformed` as well, but this requires deeper changes to leb128 parsing, so I figured we might as well land this part now.