### PR TITLE
Validate locals types

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -324,6 +324,7 @@ mod wast_tests {
     use std::fs::{read, read_dir};
     use std::str;
 
+    const WAST_TESTS_PATH: &str = "tests/wast";
     const SPEC_TESTS_PATH: &str = "testsuite";
 
     fn default_config() -> ValidatingParserConfig {
@@ -531,6 +532,26 @@ mod wast_tests {
                 _ => false,
             },
         );
+    }
+
+    #[test]
+    fn run_wast_tests() {
+        for entry in read_dir(WAST_TESTS_PATH).unwrap() {
+            let dir = entry.unwrap();
+            if !dir.file_type().unwrap().is_file()
+                || dir.path().extension().map(|s| s.to_str().unwrap()) != Some("wast")
+            {
+                continue;
+            }
+
+            let data = read(&dir.path()).expect("wast data");
+            run_wabt_scripts(
+                dir.file_name().to_str().expect("name"),
+                &data,
+                default_config(),
+                |_, _| false,
+            );
+        }
     }
 
     #[test]

--- a/tests/wast/wasmtime905.wast
+++ b/tests/wast/wasmtime905.wast
@@ -1,0 +1,4 @@
+(assert_invalid
+    (module (func (local anyref)))
+    "reference types support is not enabled"
+)


### PR DESCRIPTION
Addresses the issue at https://github.com/bytecodealliance/wasmtime/issues/905

<del>Test is not included -- currently we don't support reference-types-disabled tests in the parser.</del> Added test from the issue above.