### PR TITLE
Remove special casing for old spec test error messages

### DIFF
--- a/src/operators_validator.rs
+++ b/src/operators_validator.rs
@@ -1992,7 +1992,7 @@ impl OperatorValidator {
                 }
                 if segment >= resources.element_count() {
                     bail_op_err!(
-                        "unknown element segment {}: segment index out of bounds",
+                        "unknown elem segment {}: segment index out of bounds",
                         segment
                     );
                 }
@@ -2003,7 +2003,7 @@ impl OperatorValidator {
                 self.check_bulk_memory_enabled()?;
                 if segment >= resources.element_count() {
                     bail_op_err!(
-                        "unknown element segment {}: segment index out of bounds",
+                        "unknown elem segment {}: segment index out of bounds",
                         segment
                     );
                 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -439,16 +439,6 @@ mod wast_tests {
                         );
                     }
                     Err(e) => {
-                        if message.contains("unknown table")
-                            && e.message().contains("unknown element segment")
-                        {
-                            println!(
-                                "{}:{}: skipping until \
-                                 https://github.com/WebAssembly/testsuite/pull/18 is merged",
-                                filename, line,
-                            );
-                            continue;
-                        }
                         assert!(
                             e.message().contains(message),
                             "{file}:{line}: expected \"{spec}\", got \"{actual}\"",


### PR DESCRIPTION
Passive elements used to have a bad expected error message in the spec tests but that's since been fixed.