### PR TITLE
Add `ValidatingParser::current_position` method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.51.2"
+version = "0.51.3"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmparser.rs"

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -688,6 +688,10 @@ impl<'a> ValidatingParser<'a> {
             func_body_offset,
         ))
     }
+
+    pub fn current_poisiton(&self) -> usize {
+        self.parser.current_position()
+    }
 }
 
 impl<'a> WasmDecoder<'a> for ValidatingParser<'a> {


### PR DESCRIPTION
Hello!  I ran into an issue because I need both the current position and to be able to look at the locals of a given function while doing a validated parse.

Creating a `ValidatingOperatorParser` from a `ValidatingParser`  lets me inspect the `current_position` but it requires the position be at `BeginFunctionBody` and eats the `FunctionBodyLocals` statement with no way to inspect the locals or the previously returned value.

We may want to update `ValidatingOperatorParser` to give access to the local too but this simple fix of `ValidatingParser` providing the `current_position` method is sufficient to solve my issue!