### PR TITLE
Don't validate memories in `data.drop` instructions

### DIFF
--- a/src/operators_validator.rs
+++ b/src/operators_validator.rs
@@ -1969,7 +1969,6 @@ impl OperatorValidator {
             }
             Operator::DataDrop { segment } => {
                 self.check_bulk_memory_enabled()?;
-                self.check_memory_index(0, resources)?;
                 if segment >= resources.data_count() {
                     return Err(OperatorValidatorError::new(
                         "unknown data segment: segment index out of bounds",

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -558,6 +558,7 @@ mod wast_tests {
                 ("ref_func.wast", _) => true,
                 ("table-sub.wast", _) => true,
                 ("table_grow.wast", _) => true,
+                ("memory_init.wast", _) => true,
                 _ => false,
             },
         );


### PR DESCRIPTION
For `data.drop` nowadays we only need to validate that the data segment
is a valid index, there's no need for the module to have a defined
memory.