### PR TITLE
First steps towards Read trait parser (BrTable)

### DIFF
--- a/src/binary_reader.rs
+++ b/src/binary_reader.rs
@@ -23,7 +23,7 @@ use crate::limits::{
 };
 
 use crate::primitives::{
-    BinaryReaderError, BrTable2, CustomSectionKind, ExternalKind, FuncType, GlobalType,
+    BinaryReaderError, BrTable, CustomSectionKind, ExternalKind, FuncType, GlobalType,
     Ieee32, Ieee64, LinkingType, MemoryImmediate, MemoryType, NameType, Operator, RelocType,
     ResizableLimits, Result, SIMDLaneIndex, SectionCode, TableType, Type, TypeOrFuncType, V128,
 };
@@ -360,8 +360,8 @@ impl<'a> BinaryReader<'a> {
         }
     }
 
-    fn read_br_table(&mut self) -> Result<BrTable2> {
-        BrTable2::read_table::<crate::BrTableBuilder>(self)
+    fn read_br_table(&mut self) -> Result<BrTable> {
+        BrTable::read_table::<crate::BrTableBuilder>(self)
     }
 
     /// Returns whether the `BinaryReader` has reached the end of the file.
@@ -1682,17 +1682,17 @@ impl<'a> BinaryReader<'a> {
 
 use crate::primitives::WasmBrTableBuilder;
 
-impl BrTable2 {
+impl BrTable {
     /// Reads branch table (`br_table`) entries from the given buffer.
     ///
     /// # Examples
     ///
     /// ```rust
-    /// # use wasmparser::{BinaryReader, BrTable2, BrTableBuilder, WasmBrTable, WasmBrTableBuilder};
+    /// # use wasmparser::{BinaryReader, BrTable, BrTableBuilder, WasmBrTable, WasmBrTableBuilder};
     /// // `0x0e` (`br_table` ID) and count already parsed at this point:
     /// let buffer = vec![0x02, 0x01, 0x02, 0x00];
     /// let mut reader = BinaryReader::new(&buffer);
-    /// let br_table = BrTable2::read_table::<BrTableBuilder>(&mut reader).unwrap();
+    /// let br_table = BrTable::read_table::<BrTableBuilder>(&mut reader).unwrap();
     /// let expected = {
     ///     let mut builder = BrTableBuilder::new(2);
     ///     builder.push_target(1);

--- a/src/binary_reader.rs
+++ b/src/binary_reader.rs
@@ -23,8 +23,8 @@ use crate::limits::{
 };
 
 use crate::primitives::{
-    BinaryReaderError, BrTable, CustomSectionKind, ExternalKind, FuncType, GlobalType,
-    Ieee32, Ieee64, LinkingType, MemoryImmediate, MemoryType, NameType, Operator, RelocType,
+    BinaryReaderError, BrTable, CustomSectionKind, ExternalKind, FuncType, GlobalType, Ieee32,
+    Ieee64, LinkingType, MemoryImmediate, MemoryType, NameType, Operator, RelocType,
     ResizableLimits, Result, SIMDLaneIndex, SectionCode, TableType, Type, TypeOrFuncType, V128,
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,6 @@ pub use crate::parser::WasmDecoder;
 
 pub use crate::primitives::BinaryReaderError;
 pub use crate::primitives::BrTable;
-pub use crate::primitives::WasmBrTable;
-pub use crate::primitives::WasmBrTableBuilder;
 pub use crate::primitives::BrTableBuilder;
 pub use crate::primitives::CustomSectionKind;
 pub use crate::primitives::ExternalKind;
@@ -61,6 +59,8 @@ pub use crate::primitives::SectionCode;
 pub use crate::primitives::TableType;
 pub use crate::primitives::Type;
 pub use crate::primitives::TypeOrFuncType;
+pub use crate::primitives::WasmBrTable;
+pub use crate::primitives::WasmBrTableBuilder;
 pub use crate::primitives::V128;
 
 pub use crate::validator::validate;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,8 @@ pub use crate::parser::WasmDecoder;
 
 pub use crate::primitives::BinaryReaderError;
 pub use crate::primitives::BrTable;
+pub use crate::primitives::BrTable2;
+pub use crate::primitives::BrTableBuilder;
 pub use crate::primitives::CustomSectionKind;
 pub use crate::primitives::ExternalKind;
 pub use crate::primitives::FuncType;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,8 @@ pub use crate::parser::WasmDecoder;
 pub use crate::primitives::BinaryReaderError;
 pub use crate::primitives::BrTable;
 pub use crate::primitives::BrTable2;
+pub use crate::primitives::WasmBrTable;
+pub use crate::primitives::WasmBrTableBuilder;
 pub use crate::primitives::BrTableBuilder;
 pub use crate::primitives::CustomSectionKind;
 pub use crate::primitives::ExternalKind;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,6 @@ pub use crate::parser::RelocEntry;
 pub use crate::parser::WasmDecoder;
 
 pub use crate::primitives::BinaryReaderError;
-pub use crate::primitives::BrTable;
 pub use crate::primitives::BrTable2;
 pub use crate::primitives::WasmBrTable;
 pub use crate::primitives::WasmBrTableBuilder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub use crate::parser::RelocEntry;
 pub use crate::parser::WasmDecoder;
 
 pub use crate::primitives::BinaryReaderError;
-pub use crate::primitives::BrTable2;
+pub use crate::primitives::BrTable;
 pub use crate::primitives::WasmBrTable;
 pub use crate::primitives::WasmBrTableBuilder;
 pub use crate::primitives::BrTableBuilder;

--- a/src/operators_validator.rs
+++ b/src/operators_validator.rs
@@ -949,7 +949,11 @@ impl OperatorValidator {
                 let mut depth0: Option<u32> = None;
                 use crate::WasmBrTable as _;
                 let len_targets = table.len();
-                fn check_target(validator: &OperatorValidator, depth0: &mut Option<u32>, relative_depth: u32) -> OperatorValidatorResult<()> {
+                fn check_target(
+                    validator: &OperatorValidator,
+                    depth0: &mut Option<u32>,
+                    relative_depth: u32,
+                ) -> OperatorValidatorResult<()> {
                     if depth0.is_none() {
                         validator.check_jump_from_block(relative_depth, 1)?;
                         depth0.replace(relative_depth);
@@ -961,7 +965,8 @@ impl OperatorValidator {
                 }
                 // Check normal branch targets:
                 for i in 0..len_targets {
-                    let relative_depth = table.target_offset(i).expect("encountered missing target");
+                    let relative_depth =
+                        table.target_offset(i).expect("encountered missing target");
                     check_target(self, &mut depth0, relative_depth)?;
                 }
                 // Check default branch target:

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -104,7 +104,7 @@ pub enum ParserState<'a> {
     DataCountSectionEntry(u32),
 
     BeginInitExpressionBody,
-    InitExpressionOperator(Operator<'a>),
+    InitExpressionOperator(Operator),
     EndInitExpressionBody,
 
     BeginFunctionBody {
@@ -113,7 +113,7 @@ pub enum ParserState<'a> {
     FunctionBodyLocals {
         locals: Box<[(u32, Type)]>,
     },
-    CodeOperator(Operator<'a>),
+    CodeOperator(Operator),
     EndFunctionBody,
     SkippingFunctionBody,
 

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -261,7 +261,7 @@ pub trait WasmBrTableBuilder {
 /// A branch table (`br_table`).
 ///
 /// Stores its target and default branch offsets.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BrTable2 {
     /// Non-empty vector storing the target offsets followed by the default offset.
     targets: Box<[u32]>,

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -212,13 +212,6 @@ pub enum RelocType {
     GlobalIndexLEB,
 }
 
-/// A br_table entries representation.
-#[derive(Debug, Clone)]
-pub struct BrTable<'a> {
-    pub(crate) buffer: &'a [u8],
-    pub(crate) cnt: usize,
-}
-
 /// Trait implemented by Wasm branching table (`br_table`) operators.
 pub trait WasmBrTable {
     /// Returns the number of branching targets, not including the default label.

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -255,14 +255,14 @@ pub trait WasmBrTableBuilder {
 ///
 /// Stores its target and default branch offsets.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BrTable2 {
+pub struct BrTable {
     /// Non-empty vector storing the target offsets followed by the default offset.
     targets: Box<[u32]>,
     /// The default target offset.
     default_target: u32,
 }
 
-impl WasmBrTable for BrTable2 {
+impl WasmBrTable for BrTable {
     fn len(&self) -> usize {
         self.targets.len().saturating_sub(1)
     }
@@ -288,7 +288,7 @@ pub struct BrTableBuilder {
 }
 
 impl WasmBrTableBuilder for BrTableBuilder {
-    type BrTable = BrTable2;
+    type BrTable = BrTable;
 
     fn new(targets_hint: usize) -> Self {
         Self { targets: Vec::with_capacity(targets_hint) }
@@ -298,9 +298,9 @@ impl WasmBrTableBuilder for BrTableBuilder {
         self.targets.push(target);
     }
 
-    fn default_target(mut self, default_target: u32) -> BrTable2 {
+    fn default_target(mut self, default_target: u32) -> BrTable {
         self.targets.push(default_target);
-        BrTable2 {
+        BrTable {
             targets: self.targets.into_boxed_slice(),
             default_target,
         }
@@ -358,7 +358,7 @@ pub enum Operator {
     End,
     Br { relative_depth: u32 },
     BrIf { relative_depth: u32 },
-    BrTable { table: BrTable2 },
+    BrTable { table: BrTable },
     Return,
     Call { function_index: u32 },
     CallIndirect { index: u32, table_index: u32 },

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -240,9 +240,16 @@ pub trait WasmBrTable {
 /// while upholding its invariants throughout the building process. This way
 /// the internals of the Wasm branching table are less constraint by the build
 /// procedure.
-pub trait WasmBrTableBuilder: Default {
+pub trait WasmBrTableBuilder {
     /// The branch table that is going to be build.
     type BrTable;
+
+    /// Creates a new branch table builder.
+    ///
+    /// The `targets_hint` tells the builder how many branch targets it can
+    /// expect. This can be used by the builder in order to speed-up
+    /// the branch table construction.
+    fn new(targets_hint: usize) -> Self;
 
     /// Pushes another branching target offset to the built branch table.
     fn push_target(&mut self, offset: u32);
@@ -287,16 +294,12 @@ pub struct BrTableBuilder {
     targets: Vec<u32>,
 }
 
-impl Default for BrTableBuilder {
-    fn default() -> Self {
-        Self {
-            targets: Vec::new(),
-        }
-    }
-}
-
 impl WasmBrTableBuilder for BrTableBuilder {
     type BrTable = BrTable2;
+
+    fn new(targets_hint: usize) -> Self {
+        Self { targets: Vec::with_capacity(targets_hint) }
+    }
 
     fn push_target(&mut self, target: u32) {
         self.targets.push(target);

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -355,7 +355,7 @@ pub type SIMDLaneIndex = u8;
 ///
 /// [here]: https://webassembly.github.io/spec/core/binary/instructions.html
 #[derive(Debug, Clone)]
-pub enum Operator<'a> {
+pub enum Operator {
     Unreachable,
     Nop,
     Block { ty: TypeOrFuncType },
@@ -365,7 +365,7 @@ pub enum Operator<'a> {
     End,
     Br { relative_depth: u32 },
     BrIf { relative_depth: u32 },
-    BrTable { table: BrTable<'a> },
+    BrTable { table: BrTable2 },
     Return,
     Call { function_index: u32 },
     CallIndirect { index: u32, table_index: u32 },

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -291,7 +291,9 @@ impl WasmBrTableBuilder for BrTableBuilder {
     type BrTable = BrTable;
 
     fn new(targets_hint: usize) -> Self {
-        Self { targets: Vec::with_capacity(targets_hint) }
+        Self {
+            targets: Vec::with_capacity(targets_hint),
+        }
     }
 
     fn push_target(&mut self, target: u32) {

--- a/src/readers/operators.rs
+++ b/src/readers/operators.rs
@@ -48,7 +48,7 @@ impl<'a> OperatorsReader<'a> {
         ))
     }
 
-    pub fn read<'b>(&mut self) -> Result<Operator<'b>>
+    pub fn read<'b>(&mut self) -> Result<Operator>
     where
         'a: 'b,
     {
@@ -65,7 +65,7 @@ impl<'a> OperatorsReader<'a> {
         }
     }
 
-    pub fn read_with_offset<'b>(&mut self) -> Result<(Operator<'b>, usize)>
+    pub fn read_with_offset<'b>(&mut self) -> Result<(Operator, usize)>
     where
         'a: 'b,
     {
@@ -75,7 +75,7 @@ impl<'a> OperatorsReader<'a> {
 }
 
 impl<'a> IntoIterator for OperatorsReader<'a> {
-    type Item = Result<Operator<'a>>;
+    type Item = Result<Operator>;
     type IntoIter = OperatorsIterator<'a>;
 
     /// Reads content of the code section.
@@ -116,7 +116,7 @@ pub struct OperatorsIterator<'a> {
 }
 
 impl<'a> Iterator for OperatorsIterator<'a> {
-    type Item = Result<Operator<'a>>;
+    type Item = Result<Operator>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.err || self.reader.eof() {
@@ -134,7 +134,7 @@ pub struct OperatorsIteratorWithOffsets<'a> {
 }
 
 impl<'a> Iterator for OperatorsIteratorWithOffsets<'a> {
-    type Item = Result<(Operator<'a>, usize)>;
+    type Item = Result<(Operator, usize)>;
 
     /// Reads content of the code section with offsets.
     ///

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -853,7 +853,7 @@ impl<'b> ValidatingOperatorParser<'b> {
             MemoryType = M,
             GlobalType = G,
         >,
-    ) -> Result<Operator<'c>>
+    ) -> Result<Operator>
     where
         'b: 'c,
     {


### PR DESCRIPTION
First step towards implementing https://github.com/bytecodealliance/wasmparser/issues/90.

This refactoring of `BrTable` is required in order to drop the explicit lifetime from the `Operator` enum. We introduce the `WasmBrTable` and `WasmBrTableBuilder` traits so that we can later make `Operator` generic over user provided types for `BrTable` and maybe other custom Wasm operators and types in the future.

We separated `BrTable` and `BrTableBuilder` in order to make the more important `BrTable` less constraint regarding incremental building. At the moment we do not provide users with a way to customize the `Operator` enum so we might experience slight performance regressions since a `BrTable` now is eagerly constructed instead of deferring its construction.

In the long run this procedure should even improve performance since we no longer need to parse the `br_table` targets twice. Also in some cases we needed to construct an internal `br_table` and users would then construct their own custom `br_table` on their side. With this (and follow-up) changes we simply directly construct the user defined `br_table` directly.

## Next Steps

After merging of this PR the next steps to make the parser work on `T: Read` instead of working on a slice of `[u8]` are:

- Maybe we want to allow constructing `Result<Self::BrTable>` in `WasmBrTableBuilder` trait to allow for use cases where a user doesn't want to support `br_table` at all.
- Find any other locations where a lifetime is used in some produced data structure as it was the case for `Operator` and replace it with similar technique.
- Introduce collective trait that can be used to pass to the parser to tell it which user defined types to construct. The user has to implement this trait for some super type to enumerate all the user defined types. So far this is only needed for `BrTable` but this design is scalable for future additions.
- Change API to use `T: Read`.

## Benchmarks

Sadly I cannot test the performance implications since the benchmark harness seems to be broken on `master`. At least I get the following output on `cargo bench` with `RUST_BACKTRACE=1`:

```
Benchmarking it works benchmark: Warming up for 3.0000 sthread 'main' panicked at 'unexpected error Bad magic number (at offset 0)', benches/benchmark.rs:38:42
stack backtrace:
   0: backtrace::backtrace::libunwind::trace
             at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/libunwind.rs:86
   1: backtrace::backtrace::trace_unsynchronized
             at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/mod.rs:66
   2: std::sys_common::backtrace::_print_fmt
             at src/libstd/sys_common/backtrace.rs:78
   3: <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt
             at src/libstd/sys_common/backtrace.rs:59
   4: core::fmt::write
             at src/libcore/fmt/mod.rs:1069
   5: std::io::Write::write_fmt
             at src/libstd/io/mod.rs:1537
   6: std::sys_common::backtrace::_print
             at src/libstd/sys_common/backtrace.rs:62
   7: std::sys_common::backtrace::print
             at src/libstd/sys_common/backtrace.rs:49
   8: std::panicking::default_hook::{{closure}}
             at src/libstd/panicking.rs:198
   9: std::panicking::default_hook
             at src/libstd/panicking.rs:218
  10: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:477
  11: rust_begin_unwind
             at src/libstd/panicking.rs:385
  12: std::panicking::begin_panic_fmt
             at src/libstd/panicking.rs:339
  13: criterion::Bencher<M>::iter
  14: <criterion::routine::Function<M,F,T> as criterion::routine::Routine<M,T>>::warm_up
  15: criterion::routine::Routine::sample
  16: criterion::analysis::common
  17: criterion::benchmark_group::BenchmarkGroup<M>::bench_function
  18: criterion::Criterion<M>::bench_function
  19: benchmark::main
  20: std::rt::lang_start::{{closure}}
  21: std::rt::lang_start_internal::{{closure}}
             at src/libstd/rt.rs:52
  22: std::panicking::try::do_call
             at src/libstd/panicking.rs:297
  23: std::panicking::try
             at src/libstd/panicking.rs:274
  24: std::panic::catch_unwind
             at src/libstd/panic.rs:394
  25: std::rt::lang_start_internal
             at src/libstd/rt.rs:51
  26: main
  27: __libc_start_main
  28: _start
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

error: bench failed
```

## Doc Screenshots

![2020-05-17-161328_1711x1199_scrot](https://user-images.githubusercontent.com/8193155/82151262-f6019980-985a-11ea-8b73-6fb16cfa6d03.png)
![2020-05-17-161314_1505x1220_scrot](https://user-images.githubusercontent.com/8193155/82151265-f732c680-985a-11ea-9a54-ad861becec81.png)
![2020-05-17-161253_1500x885_scrot](https://user-images.githubusercontent.com/8193155/82151268-f7cb5d00-985a-11ea-8769-b9cf7ef2c40e.png)
